### PR TITLE
Add memory-mapped bloom filter support

### DIFF
--- a/bloom/bloom.cpp
+++ b/bloom/bloom.cpp
@@ -347,7 +347,13 @@ int bloom_init_mmap(struct bloom *bloom, uint64_t entries, long double error, co
     return 1;
   }
   close(fd);
-  memset(bloom->bf, 0, bloom->bytes);
+  /*
+   * Avoid touching the whole mapped region up front.  ftruncate() ensures the
+   * file is logically filled with zeros so we can skip the explicit memset.
+   * This allows creating bloom filters that are larger than the available
+   * RAM because the kernel will allocate pages on demand as they are
+   * accessed.
+   */
 
   bloom->ready = 1;
   bloom->major = BLOOM_VERSION_MAJOR;


### PR DESCRIPTION
## Summary
- allow configuring memory-mapped bloom filters with `--mapped-n` and `--mapped-split`
- warn when bloom filter exceeds available RAM
- avoid pre-touching memory-mapped bloom files

## Testing
- `make`
- `timeout 1 ./keyhunt --mapped-n 1000 --mapped-split 2 --mapped test.blm -m rmd160 -f tests/unsolvedpuzzles.rmd -b 66 -l compress -R -s 0`

------
https://chatgpt.com/codex/tasks/task_e_689662c95c20832eb47be7a02b640b03