### PR TITLE
Avoid unwanted truncation when mapping bloom files

### DIFF
--- a/bloom/bloom.h
+++ b/bloom/bloom.h
@@ -216,7 +216,7 @@ int bloom_reset(struct bloom * bloom);
 const char * bloom_version();
 
 /* Additional helpers for memory mapped bloom filters */
-int bloom_init_mmap(struct bloom * bloom, uint64_t entries, long double error, const char *filename);
+int bloom_init_mmap(struct bloom * bloom, uint64_t entries, long double error, const char *filename, int resize);
 void bloom_unmap(struct bloom * bloom);
 
 #ifdef __cplusplus

--- a/keyhunt.cpp
+++ b/keyhunt.cpp
@@ -6649,7 +6649,7 @@ bool initBloomFilterMapped(struct bloom *bloom_arg,uint64_t items_bloom) {
                 printf("[+] Bloom filter for %" PRIu64 " elements.\n",items_bloom);
                 const char *fname = mapped_filename ? mapped_filename : "bloom.dat";
                 uint64_t total = mapped_entries_override ? mapped_entries_override : ((items_bloom <= 10000)?10000:FLAGBLOOMMULTIPLIER*items_bloom);
-                if(bloom_init_mmap(bloom_arg,total,0.000001,fname) == 1){
+                if(bloom_init_mmap(bloom_arg,total,0.000001,fname, mapped_entries_override != 0) == 1){
                         fprintf(stderr,"[E] error bloom_init_mmap for %" PRIu64 " elements.\n",items_bloom);
                         r = false;
                 }


### PR DESCRIPTION
## Summary
- Avoid truncating existing bloom files unless resizing was explicitly requested
- Handle mismatched bloom file sizes and report errors
- Allow mapping existing bloom files without altering contents

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_689689820178832e958cfa19d8f00b0d