### PR TITLE
Add support for chunked mapped bloom filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ You need to add `-t numberThreads` and `-k factor` to get better speed
 Keyhunt can store the bloom filter directly on disk so it can grow beyond available RAM.
 Use `--mapped[=file]` to create or use a file backed bloom filter. The optional
 `--mapped-size <entries>` flag reserves space for a specific number of entries when
-creating the mapped file. Without `--mapped`, keyhunt will keep the bloom filter in
-memory and will warn if it does not fit in the available RAM.
+creating the mapped file. `--mapped-chunks <n>` splits the filter across `n`
+sequential chunk files (e.g. `bloom.dat.0`, `bloom.dat.1`, ...). Without
+`--mapped`, keyhunt will keep the bloom filter in memory and will warn if it does
+not fit in the available RAM.
 
 ## Free Code
 

--- a/bloom/bloom.h
+++ b/bloom/bloom.h
@@ -41,7 +41,11 @@ struct bloom
   uint8_t major;
   uint8_t minor;
   double bpe;
-  uint8_t *bf;
+    uint8_t *bf;
+    uint8_t **bf_chunks;
+    uint32_t mapped_chunks;
+    uint64_t chunk_bytes;
+    uint64_t last_chunk_bytes;
 };
 /*
 Customs
@@ -216,7 +220,7 @@ int bloom_reset(struct bloom * bloom);
 const char * bloom_version();
 
 /* Additional helpers for memory mapped bloom filters */
-int bloom_init_mmap(struct bloom * bloom, uint64_t entries, long double error, const char *filename, int resize);
+int bloom_init_mmap(struct bloom * bloom, uint64_t entries, long double error, const char *filename, int resize, uint32_t chunks);
 void bloom_unmap(struct bloom * bloom);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
- add `--mapped-chunks` flag to split a mapped bloom filter into multiple files
- track and access multiple mapped segments in bloom initialization and helpers
- document the new flag in README

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68968e2f7f48832eb2608bcf2d32f568