### PR TITLE
Add bloom-bytes option for mapped bloom filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,12 @@ You need to add `-t numberThreads` and `-k factor` to get better speed
 Keyhunt can store the bloom filter directly on disk so it can grow beyond available RAM.
 Use `--mapped[=file]` to create or use a file backed bloom filter. The optional
 `--mapped-size <entries>` flag reserves space for a specific number of entries when
-creating the mapped file. `--mapped-chunks <n>` splits the filter across `n`
-sequential chunk files (e.g. `bloom.dat.0`, `bloom.dat.1`, ...). Without
-`--mapped`, keyhunt will keep the bloom filter in memory and will warn if it does
-not fit in the available RAM.
+creating the mapped file. `--bloom-bytes <size>` lets you request an approximate
+on-disk size directly, choosing the closest valid number of entries and hash
+functions. `--mapped-chunks <n>` splits the filter across `n` sequential chunk
+files (e.g. `bloom.dat.0`, `bloom.dat.1`, ...). Without `--mapped`, keyhunt will
+keep the bloom filter in memory and will warn if it does not fit in the available
+RAM.
 
 ## Free Code
 


### PR DESCRIPTION
## Summary
- Add `--bloom-bytes` flag to request a specific on-disk size for memory mapped bloom filters
- Derive appropriate entry count and hash function count from requested size using power-of-two table
- Warn when mapped bloom file would exceed available disk space and document new option

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6896a95ff120832eb275bee1d3af3bf4