### PR TITLE
Use mmap for bloom filter loading

### DIFF
--- a/bloom/bloom.cpp
+++ b/bloom/bloom.cpp
@@ -524,7 +524,7 @@ int bloom_init_mmap(struct bloom *bloom, uint64_t entries, long double error, co
 
 void bloom_unmap(struct bloom *bloom)
 {
-  if (bloom->mapped_chunks > 1 && bloom->bf_chunks) {
+  if (bloom->mapped_chunks >= 1 && bloom->bf_chunks) {
     for (uint32_t i = 0; i < bloom->mapped_chunks; i++) {
       uint64_t cbytes = (i == bloom->mapped_chunks - 1) ? bloom->last_chunk_bytes : bloom->chunk_bytes;
       if (bloom->bf_chunks[i] && cbytes) {

--- a/keyhunt.cpp
+++ b/keyhunt.cpp
@@ -6262,22 +6262,57 @@ bool readFileAddress(char *fileName)	{
 				return false;
 			}
 			
-			printf("[+] Bloom filter for %" PRIu64 " elements.\n",bloom.entries);
-			
-			bloom.bf = (uint8_t*) malloc(bloom.bytes);
-			if(bloom.bf == NULL)	{
-				fprintf(stderr,"[E] Error allocating memory, code line %i\n",__LINE__ - 2);
-				fclose(fileDescriptor);
-				return false;
-			}
+	printf("[+] Bloom filter for %" PRIu64 " elements.\n",bloom.entries);
 
-			//read bloom filter data
-			bytesRead = fread(bloom.bf,1,bloom.bytes,fileDescriptor);
-			if(bytesRead != bloom.bytes)	{
-				fprintf(stderr,"[E] Error reading file, code line %i\n",__LINE__ - 2);
-				fclose(fileDescriptor);
-				return false;
-			}
+#if defined(_WIN64) && !defined(__CYGWIN__)
+	bloom.bf = (uint8_t*) malloc(bloom.bytes);
+	if(bloom.bf == NULL)  {
+		fprintf(stderr,"[E] Error allocating memory, code line %i\n",__LINE__ - 2);
+		fclose(fileDescriptor);
+		return false;
+	}
+
+	//read bloom filter data
+	bytesRead = fread(bloom.bf,1,bloom.bytes,fileDescriptor);
+	if(bytesRead != bloom.bytes)    {
+		fprintf(stderr,"[E] Error reading file, code line %i\n",__LINE__ - 2);
+		fclose(fileDescriptor);
+		return false;
+	}
+#else
+	int fd = fileno(fileDescriptor);
+	off_t offset = ftello(fileDescriptor);
+	long pagesize = sysconf(_SC_PAGE_SIZE);
+	off_t page_offset = offset & ~((off_t)pagesize - 1);
+	off_t delta = offset - page_offset;
+	size_t map_length = bloom.bytes + delta;
+	void *map = mmap(NULL, map_length, PROT_READ, MAP_PRIVATE, fd, page_offset);
+	if (map == MAP_FAILED) {
+		fprintf(stderr,"[E] Error mmapping file, code line %i\n",__LINE__ - 2);
+		fclose(fileDescriptor);
+		return false;
+	}
+	bloom.bf = (uint8_t*)map + delta;
+	bloom.bf_chunks = (uint8_t**)calloc(1, sizeof(uint8_t*));
+	if (!bloom.bf_chunks) {
+		fprintf(stderr,"[E] Error allocating memory, code line %i\n",__LINE__ - 2);
+		munmap(map, map_length);
+		fclose(fileDescriptor);
+		return false;
+	}
+	bloom.bf_chunks[0] = (uint8_t*)map;
+	bloom.mapped_chunks = 1;
+	bloom.chunk_bytes = map_length;
+	bloom.last_chunk_bytes = map_length;
+	if (fseeko(fileDescriptor, bloom.bytes, SEEK_CUR) != 0) {
+		fprintf(stderr,"[E] Error seeking file, code line %i\n",__LINE__ - 2);
+		munmap(map, map_length);
+		fclose(fileDescriptor);
+		return false;
+	}
+	FLAGMAPPED = 1;
+	bytesRead = bloom.bytes;
+#endif
 			if(FLAGSKIPCHECKSUM == 0){
 				
 				//calculate checksum of the current readed data


### PR DESCRIPTION
## Summary
- Map bloom filter data directly in `readFileAddress` instead of copying
- Track mapped memory for cleanup via `bloom_unmap`
- Support single-chunk mappings in `bloom_unmap`

## Testing
- `make`
- `make legacy`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_6896baf76030832e93512850e9494fe3