### PR TITLE
Add n/k validation and document ranges

### DIFF
--- a/bsgsd.cpp
+++ b/bsgsd.cpp
@@ -399,6 +399,18 @@ int main(int argc, char **argv)	{
 	
 
 
+        uint64_t nk_n = 0x100000000000ULL;
+        if(FLAG_N) {
+                if(str_N[0] == '0' && (str_N[1] == 'x' || str_N[1] == 'X')) {
+                        nk_n = strtoull(str_N+2, NULL, 16);
+                } else {
+                        nk_n = strtoull(str_N, NULL, 10);
+                }
+        }
+        if(!validate_nk(nk_n, (uint64_t)KFACTOR)) {
+                exit(0);
+        }
+
 	stride.Set(&ONE);
 	init_generator();
 	
@@ -2282,16 +2294,19 @@ void menu() {
 	printf("\nUsage:\n");
 	printf("-h          show this help\n");
 	printf("-k value    Use this only with bsgs mode, k value is factor for M, more speed but more RAM use wisely\n");
+        printf("            K must not exceed the maximum allowed for N (see table below)\n");
 	printf("-n number   Check for N sequential numbers before the random chosen, this only works with -R option\n");
+        printf("            Use -n to set the N for the BSGS process. Bigger N more RAM needed (N >= 2^20)\n");
+        printf("            Valid N and K pairs are listed below\n");
 	printf("-t tn       Threads number, must be a positive integer\n");
 	printf("-p port     TCP port Number for listening conections");
 	printf("-i ip		IP Address for listening conections");
-	printf("\nExample:\n\n");
-	printf("./bsgs -k 512 \n\n");
-	exit(EXIT_FAILURE);
+        printf("\nValid n and maximum k values:\n");
+        print_nk_table();
+        printf("\nExample:\n\n");
+        printf("./bsgs -k 512 \n\n");
+        exit(EXIT_FAILURE);
 }
-
-
 void checkpointer(void *ptr,const char *file,const char *function,const  char *name,int line)	{
 	if(ptr == NULL)	{
 		fprintf(stderr,"[E] error in file %s, %s pointer %s on line %i\n",file,function,name,line); 

--- a/keyhunt.cpp
+++ b/keyhunt.cpp
@@ -11,6 +11,7 @@ email: albertobsd@gmail.com
 #include <time.h>
 #include <vector>
 #include <inttypes.h>
+#include <errno.h>
 #include "base58/libbase58.h"
 #include "rmd160/rmd160.h"
 #include "oldbloom/oldbloom.h"
@@ -823,6 +824,18 @@ int main(int argc, char **argv)	{
 		}
 	}
 	
+        uint64_t nk_n = 0x100000000000ULL;
+        if(FLAG_N) {
+                if(str_N[0] == '0' && (str_N[1] == 'x' || str_N[1] == 'X')) {
+                        nk_n = strtoull(str_N+2, NULL, 16);
+                } else {
+                        nk_n = strtoull(str_N, NULL, 10);
+                }
+        }
+        if(!validate_nk(nk_n, (uint64_t)KFACTOR)) {
+                exit(EXIT_FAILURE);
+        }
+
 	if(  FLAGBSGSMODE == MODE_BSGS && FLAGENDOMORPHISM)	{
 		fprintf(stderr,"[E] Endomorphism doesn't work with BSGS\n");
 		exit(EXIT_FAILURE);
@@ -5830,12 +5843,14 @@ void menu() {
 	printf("-e          Enable endomorphism search (Only for address, rmd160 and vanity)\n");
 	printf("-f file     Specify file name with addresses or xpoints or uncompressed public keys\n");
 	printf("-I stride   Stride for xpoint, rmd160 and address, this option don't work with bsgs\n");
-	printf("-k value    Use this only with bsgs mode, k value is factor for M, more speed but more RAM use wisely\n");
+        printf("-k value    Use this only with bsgs mode, k value is factor for M, more speed but more RAM use wisely\n");
+        printf("            K must not exceed the maximum allowed for N (see table below)\n");
 	printf("-l look     What type of address/hash160 are you looking for <compress, uncompress, both> Only for rmd160 and address\n");
 	printf("-m mode     mode of search for cryptos. (bsgs, xpoint, rmd160, address, vanity) default: address\n");
 	printf("-M          Matrix screen, feel like a h4x0r, but performance will dropped\n");
-	printf("-n number   Check for N sequential numbers before the random chosen, this only works with -R option\n");
-	printf("            Use -n to set the N for the BSGS process. Bigger N more RAM needed\n");
+        printf("-n number   Check for N sequential numbers before the random chosen, this only works with -R option\n");
+        printf("            Use -n to set the N for the BSGS process. Bigger N more RAM needed (N >= 2^20)\n");
+        printf("            Valid N and K pairs are listed below\n");
 	printf("-q          Quiet the thread output\n");
 	printf("-r SR:EN    StarRange:EndRange, the end range can be omitted for search from start range to N-1 ECC value\n");
 	printf("-R          Random, this is the default behavior\n");
@@ -5849,6 +5864,8 @@ void menu() {
         printf("--mapped-size n   Reserve space for n entries in the mapped bloom file\n");
         printf("--mapped-chunks n Split the mapped bloom filter into n chunk files\n");
        printf("--bloom-bytes sz  Desired on-disk size for mapped bloom filter in bytes\n");
+        printf("\nValid n and maximum k values:\n");
+        print_nk_table();
         printf("\nExample:\n\n");
 	printf("./keyhunt -m rmd160 -f tests/unsolvedpuzzles.rmd -b 66 -l compress -R -q -t 8\n\n");
 	printf("This line runs the program with 8 threads from the range 20000000000000000 to 40000000000000000 without stats output\n\n");

--- a/keyhunt_legacy.cpp
+++ b/keyhunt_legacy.cpp
@@ -11,6 +11,7 @@ email: albertobsd@gmail.com
 #include <time.h>
 #include <vector>
 #include <inttypes.h>
+#include <errno.h>
 #include "base58/libbase58.h"
 #include "oldbloom/oldbloom.h"
 #include "bloom/bloom.h"
@@ -780,6 +781,18 @@ int main(int argc, char **argv)	{
 		}
 	}
 	//if(FLAGDEBUG) { printf("[D] File: %s Line %i\n",__FILE__,__LINE__); fflush(stdout); }
+    uint64_t nk_n = 0x100000000000ULL;
+    if(FLAG_N) {
+        if(str_N[0] == '0' && (str_N[1] == 'x' || str_N[1] == 'X')) {
+            nk_n = strtoull(str_N+2, NULL, 16);
+        } else {
+            nk_n = strtoull(str_N, NULL, 10);
+        }
+    }
+    if(!validate_nk(nk_n, (uint64_t)KFACTOR)) {
+        exit(EXIT_FAILURE);
+    }
+
 	if(  FLAGBSGSMODE == MODE_BSGS && FLAGENDOMORPHISM)	{
 		fprintf(stderr,"[E] Endomorphism doesn't work with BSGS\n");
 		exit(EXIT_FAILURE);
@@ -6005,12 +6018,14 @@ void menu() {
 	printf("-e          Enable endomorphism search (Only for address, rmd160 and vanity)\n");
 	printf("-f file     Specify file name with addresses or xpoints or uncompressed public keys\n");
 	printf("-I stride   Stride for xpoint, rmd160 and address, this option don't work with bsgs\n");
-	printf("-k value    Use this only with bsgs mode, k value is factor for M, more speed but more RAM use wisely\n");
+        printf("-k value    Use this only with bsgs mode, k value is factor for M, more speed but more RAM use wisely\n");
+        printf("            K must not exceed the maximum allowed for N (see table below)\n");
 	printf("-l look     What type of address/hash160 are you looking for <compress, uncompress, both> Only for rmd160 and address\n");
 	printf("-m mode     mode of search for cryptos. (bsgs, xpoint, rmd160, address, vanity) default: address\n");
 	printf("-M          Matrix screen, feel like a h4x0r, but performance will dropped\n");
-	printf("-n number   Check for N sequential numbers before the random chosen, this only works with -R option\n");
-	printf("            Use -n to set the N for the BSGS process. Bigger N more RAM needed\n");
+        printf("-n number   Check for N sequential numbers before the random chosen, this only works with -R option\n");
+        printf("            Use -n to set the N for the BSGS process. Bigger N more RAM needed (N >= 2^20)\n");
+        printf("            Valid N and K pairs are listed below\n");
 	printf("-q          Quiet the thread output\n");
 	printf("-r SR:EN    StarRange:EndRange, the end range can be omitted for search from start range to N-1 ECC value\n");
 	printf("-R          Random, this is the default behavior\n");
@@ -6018,8 +6033,10 @@ void menu() {
 	printf("-S          S is for SAVING in files BSGS data (Bloom filters and bPtable)\n");
 	printf("-t tn       Threads number, must be a positive integer\n");
 	printf("-v value    Search for vanity Address, only with -m address and rmd160\n");
-	printf("-z value    Bloom size multiplier, only address,rmd160,vanity, xpoint, value >= 1\n");
-	printf("\nExample:\n\n");
+        printf("-z value    Bloom size multiplier, only address,rmd160,vanity, xpoint, value >= 1\n");
+        printf("\nValid n and maximum k values:\n");
+        print_nk_table();
+        printf("\nExample:\n\n");
 	printf("./keyhunt -m rmd160 -f tests/unsolvedpuzzles.rmd -b 66 -l compress -R -q -t 8\n\n");
 	printf("This line runs the program with 8 threads from the range 20000000000000000 to 40000000000000000 without stats output\n\n");
 	printf("Developed by AlbertoBSD\tTips BTC: 1Coffee1jV4gB5gaXfHgSHDz9xx9QSECVW\n");

--- a/util.c
+++ b/util.c
@@ -1,6 +1,8 @@
 #include <cstring>
 #include <cstdio>
 #include <cstdlib>
+#include <cstdint>
+#include <inttypes.h>
 
 #include "util.h"
 
@@ -174,5 +176,68 @@ int isValidHex(char *data)	{
 		c = data[i];
 		valid = ( (c >= '0' && c <='9') || (c >= 'A' && c <='F' ) || (c >= 'a' && c <='f' ) );
 	}
-	return valid;
+        return valid;
+}
+
+int validate_nk(uint64_t n, uint64_t k) {
+        if(n < (1ULL << 20)) {
+                fprintf(stderr,"[E] n must be at least 2^20 (0x100000)\n");
+                return 0;
+        }
+        if(n & (n - 1)) {
+                fprintf(stderr,"[E] n must be a power of two\n");
+                return 0;
+        }
+        static const struct { int bits; uint64_t k; } table[] = {
+                {20,1},{22,2},{24,4},{26,8},{28,16},{30,32},{32,64},{34,128},{36,256},
+                {38,512},{40,1024},{42,2048},{44,4096},{46,8192},{48,16384},{50,32768},
+                {52,65536},{54,131072},{56,262144},{58,524288},{60,1048576},{62,2097152},{64,4194304}
+        };
+        int bits = 0;
+        uint64_t tmp = n;
+        while(tmp > 1) {
+                tmp >>= 1;
+                bits++;
+        }
+        for(unsigned int i=0; i<sizeof(table)/sizeof(table[0]); i++) {
+                if(table[i].bits == bits) {
+                        if(k > table[i].k) {
+                                fprintf(stderr,"[E] k value %" PRIu64 " is too large for n 0x%" PRIx64 " (max %" PRIu64 ")\n",k,n,table[i].k);
+                                return 0;
+                        }
+                        return 1;
+                }
+        }
+        fprintf(stderr,"[E] invalid n 0x%" PRIx64 "\n",n);
+        return 0;
+}
+
+void print_nk_table(void) {
+        printf("+------+----------------------+-------------+\n");
+        printf("| bits |  n in hexadecimal    | k max value |\n");
+        printf("+------+----------------------+-------------+\n");
+        printf("|   20 |             0x100000 | 1 (default) |\n");
+        printf("|   22 |             0x400000 | 2           |\n");
+        printf("|   24 |            0x1000000 | 4           |\n");
+        printf("|   26 |            0x4000000 | 8           |\n");
+        printf("|   28 |           0x10000000 | 16          |\n");
+        printf("|   30 |           0x40000000 | 32          |\n");
+        printf("|   32 |          0x100000000 | 64          |\n");
+        printf("|   34 |          0x400000000 | 128         |\n");
+        printf("|   36 |         0x1000000000 | 256         |\n");
+        printf("|   38 |         0x4000000000 | 512         |\n");
+        printf("|   40 |        0x10000000000 | 1024        |\n");
+        printf("|   42 |        0x40000000000 | 2048        |\n");
+        printf("|   44 |       0x100000000000 | 4096        |\n");
+        printf("|   46 |       0x400000000000 | 8192        |\n");
+        printf("|   48 |      0x1000000000000 | 16384       |\n");
+        printf("|   50 |      0x4000000000000 | 32768       |\n");
+        printf("|   52 |     0x10000000000000 | 65536       |\n");
+        printf("|   54 |     0x40000000000000 | 131072      |\n");
+        printf("|   56 |    0x100000000000000 | 262144      |\n");
+        printf("|   58 |    0x400000000000000 | 524288      |\n");
+        printf("|   60 |   0x1000000000000000 | 1048576     |\n");
+        printf("|   62 |   0x4000000000000000 | 2097152     |\n");
+        printf("|   64 |  0x10000000000000000 | 4194304     |\n");
+        printf("+------+----------------------+-------------+\n");
 }

--- a/util.h
+++ b/util.h
@@ -1,6 +1,7 @@
 #ifndef CUSTOMUTILH
 #define CUSTOMUTILH
 
+#include <stdint.h>
 typedef struct str_list	{
 	int n;
 	char **data;
@@ -29,5 +30,8 @@ char *nextToken(Tokenizer *t);
 int isValidHex(char *data);
 void freetokenizer(Tokenizer *t);
 void stringtokenizer(char *data,Tokenizer *t);
+
+int validate_nk(uint64_t n, uint64_t k);
+void print_nk_table(void);
 
 #endif // CUSTOMUTILH


### PR DESCRIPTION
## Summary
- add helper to validate N and K combinations and expose valid table
- enforce N/K limits in keyhunt, legacy and bsgsd modes
- document N and K ranges in CLI help output

## Testing
- `make`
- `make bsgsd`
- `make legacy`


------
https://chatgpt.com/codex/tasks/task_e_6896be6c8f40832e8db2562acb0ba3ba