### PR TITLE
Support loading existing mapped bloom filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ You need to add `-t numberThreads` and `-k factor` to get better speed
 ### Memory mapped bloom filters
 
 Keyhunt can store the bloom filter directly on disk so it can grow beyond available RAM.
-Use `--mapped[=file]` to create or use a file backed bloom filter. The optional
-`--mapped-size <size>` flag reserves space for a mapped bloom filter file of the
-given size in bytes. Suffixes `K`, `M`, `G`, and `T` are supported, and the size
-is converted to a number of entries internally. `--bloom-bytes <size>` lets you
+Use `--mapped[=file]` to create or reuse a file backed bloom filter. If the
+specified file already exists and `--mapped-size` is not provided, keyhunt will
+load the existing bloom filter in place. The optional `--mapped-size <size>` flag
+reserves space for a mapped bloom filter file of the given size in bytes.
+Suffixes `K`, `M`, `G`, and `T` are supported, and the size is converted to a
+number of entries internally. `--bloom-bytes <size>` lets you
 request an approximate on-disk size directly, choosing the closest valid number
 of entries and hash functions. `--mapped-chunks <n>` splits the filter across `n`
 sequential chunk files (e.g. `bloom.dat.0`, `bloom.dat.1`, ...). Use

--- a/bloom/bloom.h
+++ b/bloom/bloom.h
@@ -221,6 +221,7 @@ const char * bloom_version();
 
 /* Additional helpers for memory mapped bloom filters */
 int bloom_init_mmap(struct bloom * bloom, uint64_t entries, long double error, const char *filename, int resize, uint32_t chunks);
+int bloom_load_mmap(struct bloom * bloom, const char *filename, uint32_t chunks);
 void bloom_unmap(struct bloom * bloom);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
- Add `bloom_load_mmap` to map existing bloom filter files and populate size, entry and hash metadata.
- Reuse existing mapped bloom filters in `initBloomFilterMapped` when `--mapped` is specified without `--mapped-size`.
- Document mapped filter reuse and `--mapped` behavior in README and CLI help.

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689728196cb8832e819e73d89fc9b99a