### PR TITLE
Add tmpdir option for mapped bP table files

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ supplied, keyhunt stores this table in a temporary file and maps it into
 memory.  `--ptable[=file]` selects the backing file path and
 `--ptable-size <size>` preallocates the file (accepting `K`, `M`, `G` and `T`
 suffixes).  The mapped table is flushed on shutdown and the temporary file is
-removed unless a path was explicitly provided.
+removed unless a path was explicitly provided. By default the file is created
+in the system temporary directory; use `--tmpdir <dir>` or set `TEMP`/`TMPDIR`
+to choose a different location.
 
 ## Free Code
 

--- a/keyhunt.cpp
+++ b/keyhunt.cpp
@@ -312,6 +312,7 @@ int bptable_fd = -1;
 uint64_t bptable_bytes = 0;
 int FLAGBPTABLEMAPPED = 0;
 char bptable_tmpfile[4096];
+const char *tmpdir_path = NULL;
 int KFACTOR = 1;
 int MAXLENGTHADDRESS = -1;
 int NTHREADS = 1;
@@ -523,6 +524,7 @@ int main(int argc, char **argv)	{
                {"ptable-size", required_argument, 0, 0},
                {"bloom-bytes", required_argument, 0, 0},
                {"create-mapped", optional_argument, 0, 0},
+               {"tmpdir", required_argument, 0, 0},
                {0, 0, 0, 0}
        };
 
@@ -585,6 +587,8 @@ int main(int argc, char **argv)	{
                                       mapped_entries_override = n;
                                       mapped_error_override = powl(0.5L, (long double)k);
                               }
+                      } else if (strcmp(long_options[option_index].name, "tmpdir") == 0) {
+                              tmpdir_path = optarg;
                       }
                       continue;
               }
@@ -1555,7 +1559,12 @@ int main(int argc, char **argv)	{
                        if(fname){
                                bptable_fd = open(fname,O_RDWR | O_CREAT,0600);
                        }else{
-                               strcpy(bptable_tmpfile,"/tmp/bptableXXXXXX");
+                               const char *tmp = tmpdir_path;
+                               if(!tmp || !*tmp) tmp = getenv("TMPDIR");
+                               if(!tmp || !*tmp) tmp = getenv("TEMP");
+                               if(!tmp || !*tmp) tmp = getenv("TMP");
+                               if(!tmp || !*tmp) tmp = "/tmp";
+                               snprintf(bptable_tmpfile,sizeof(bptable_tmpfile),"%s/bptableXXXXXX",tmp);
                                bptable_fd = mkstemp(bptable_tmpfile);
                        }
                        if(bptable_fd < 0){
@@ -6026,6 +6035,7 @@ void menu() {
        printf("--create-mapped[=sz]  Create and zero a mapped bloom filter file then exit\n");
        printf("--ptable[=file]   Use a memory-mapped file for the bP table\n");
        printf("--ptable-size sz  Preallocate sz bytes for the mapped bP table (supports K/M/G/T)\n");
+       printf("--tmpdir dir     Directory for temporary files\n");
         printf("\nValid n and maximum k values:\n");
         print_nk_table();
         printf("\nExample:\n\n");

--- a/keyhunt_legacy.cpp
+++ b/keyhunt_legacy.cpp
@@ -310,6 +310,7 @@ int bptable_fd = -1;
 uint64_t bptable_bytes = 0;
 int FLAGBPTABLEMAPPED = 0;
 char bptable_tmpfile[4096];
+const char *tmpdir_path = NULL;
 
 
 int FLAGSTRIDE = 0;
@@ -510,6 +511,7 @@ int main(int argc, char **argv)	{
                {"mapped", optional_argument, 0, 0},
                {"ptable", optional_argument, 0, 0},
                {"ptable-size", required_argument, 0, 0},
+               {"tmpdir", required_argument, 0, 0},
                {0, 0, 0, 0}
        };
 
@@ -536,6 +538,8 @@ int main(int argc, char **argv)	{
                                        }
                                }
                                bptable_size_override = desired;
+                       } else if(strcmp(long_options[option_index].name,"tmpdir") == 0){
+                               tmpdir_path = optarg;
                        }
                        continue;
                }
@@ -1455,7 +1459,12 @@ int main(int argc, char **argv)	{
                        if(fname){
                                bptable_fd = open(fname,O_RDWR | O_CREAT,0600);
                        }else{
-                               strcpy(bptable_tmpfile,"/tmp/bptableXXXXXX");
+                               const char *tmp = tmpdir_path;
+                               if(!tmp || !*tmp) tmp = getenv("TMPDIR");
+                               if(!tmp || !*tmp) tmp = getenv("TEMP");
+                               if(!tmp || !*tmp) tmp = getenv("TMP");
+                               if(!tmp || !*tmp) tmp = "/tmp";
+                               snprintf(bptable_tmpfile,sizeof(bptable_tmpfile),"%s/bptableXXXXXX",tmp);
                                bptable_fd = mkstemp(bptable_tmpfile);
                        }
                        if(bptable_fd < 0){
@@ -6164,6 +6173,7 @@ void menu() {
        printf("--mapped    Force use of a memory-mapped file for bP table\n");
        printf("--ptable[=file]   Path to backing file for mapped bP table\n");
        printf("--ptable-size sz  Preallocate sz bytes for mapped bP table (supports K/M/G/T)\n");
+       printf("--tmpdir dir     Directory for temporary files\n");
         printf("\nValid n and maximum k values:\n");
         print_nk_table();
         printf("\nExample:\n\n");


### PR DESCRIPTION
## Summary
- allow specifying the directory for temporary mapped files via `--tmpdir`
- fall back to `TEMP`/`TMPDIR` environment variables before defaulting to `/tmp`
- document new `--tmpdir` option in README and usage

## Testing
- `make`
- `make legacy`


------
https://chatgpt.com/codex/tasks/task_e_689799e73638832e8bf8dc350d64adc8