### PR TITLE
Add arm64 build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,61 +1,84 @@
+ARCH := $(shell uname -m)
+
+ifeq ($(ARCH),aarch64)
+ARCH_FLAGS := -march=armv8-a -mtune=generic
+HASH_OBJS := hash/ripemd160.o hash/sha256.o
+else
+ARCH_FLAGS := -m64 -march=native -mtune=native -mssse3
+HASH_OBJS := hash/ripemd160.o hash/sha256.o hash/ripemd160_sse.o hash/sha256_sse.o
+endif
+
+CXXFLAGS := $(ARCH_FLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize
+CFLAGS := $(ARCH_FLAGS) -Wall -Wextra -Ofast -ftree-vectorize
+
+.RECIPEPREFIX = >
+
 default:
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c oldbloom/bloom.cpp -o oldbloom.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c bloom/bloom.cpp -o bloom.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-unused-parameter -Ofast -ftree-vectorize -c base58/base58.c -o base58.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Ofast -ftree-vectorize -c rmd160/rmd160.c -o rmd160.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c sha3/sha3.c -o sha3.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c sha3/keccak.c -o keccak.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Ofast -ftree-vectorize -c xxhash/xxhash.c -o xxhash.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c util.c -o util.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Int.cpp -o Int.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Point.cpp -o Point.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/SECP256K1.cpp -o SECP256K1.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/IntMod.cpp -o IntMod.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c secp256k1/Random.cpp -o Random.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c secp256k1/IntGroup.cpp -o IntGroup.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/ripemd160.o -ftree-vectorize -flto -c hash/ripemd160.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256.o -ftree-vectorize -flto -c hash/sha256.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/ripemd160_sse.o -ftree-vectorize -flto -c hash/ripemd160_sse.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256_sse.o -ftree-vectorize -flto -c hash/sha256_sse.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -o keyhunt keyhunt.cpp base58.o rmd160.o hash/ripemd160.o hash/ripemd160_sse.o hash/sha256.o hash/sha256_sse.o bloom.o oldbloom.o xxhash.o util.o Int.o  Point.o SECP256K1.o  IntMod.o  Random.o IntGroup.o sha3.o keccak.o  -lm -lpthread
-	rm -r *.o
+>g++ $(CXXFLAGS) -flto -c oldbloom/bloom.cpp -o oldbloom.o
+>g++ $(CXXFLAGS) -flto -c bloom/bloom.cpp -o bloom.o
+>gcc $(CFLAGS) -Wno-unused-parameter -c base58/base58.c -o base58.o
+>gcc $(CFLAGS) -c rmd160/rmd160.c -o rmd160.o
+>g++ $(CXXFLAGS) -c sha3/sha3.c -o sha3.o
+>g++ $(CXXFLAGS) -c sha3/keccak.c -o keccak.o
+>gcc $(CFLAGS) -c xxhash/xxhash.c -o xxhash.o
+>g++ $(CXXFLAGS) -c util.c -o util.o
+>g++ $(CXXFLAGS) -c secp256k1/Int.cpp -o Int.o
+>g++ $(CXXFLAGS) -c secp256k1/Point.cpp -o Point.o
+>g++ $(CXXFLAGS) -c secp256k1/SECP256K1.cpp -o SECP256K1.o
+>g++ $(CXXFLAGS) -c secp256k1/IntMod.cpp -o IntMod.o
+>g++ $(CXXFLAGS) -flto -c secp256k1/Random.cpp -o Random.o
+>g++ $(CXXFLAGS) -flto -c secp256k1/IntGroup.cpp -o IntGroup.o
+>g++ $(CXXFLAGS) -flto -c hash/ripemd160.cpp -o hash/ripemd160.o
+>g++ $(CXXFLAGS) -flto -c hash/sha256.cpp -o hash/sha256.o
+ifneq ($(ARCH),aarch64)
+>g++ $(CXXFLAGS) -flto -c hash/ripemd160_sse.cpp -o hash/ripemd160_sse.o
+>g++ $(CXXFLAGS) -flto -c hash/sha256_sse.cpp -o hash/sha256_sse.o
+endif
+>g++ $(CXXFLAGS) -o keyhunt keyhunt.cpp base58.o rmd160.o $(HASH_OBJS) bloom.o oldbloom.o xxhash.o util.o Int.o Point.o SECP256K1.o IntMod.o Random.o IntGroup.o sha3.o keccak.o -lm -lpthread
+>rm -r *.o
+
 clean:
-	rm keyhunt
+>rm -f keyhunt
+
 legacy:
-	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -flto -c oldbloom/bloom.cpp -o oldbloom.o
-	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -flto -c bloom/bloom.cpp -o bloom.o
-	gcc -march=native -mtune=native -Wno-unused-result -Ofast -ftree-vectorize -c base58/base58.c -o base58.o
-	gcc -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -c xxhash/xxhash.c -o xxhash.o
-	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -c util.c -o util.o
-	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -c sha3/sha3.c -o sha3.o
-	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -c sha3/keccak.c -o keccak.o
-	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -c hashing.c -o hashing.o
-	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -c gmp256k1/Int.cpp -o Int.o
-	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -c gmp256k1/Point.cpp -o Point.o
-	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -c gmp256k1/GMP256K1.cpp -o GMP256K1.o
-	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -c gmp256k1/IntMod.cpp -o IntMod.o
-	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -flto -c gmp256k1/Random.cpp -o Random.o
-	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -flto -c gmp256k1/IntGroup.cpp -o IntGroup.o
-	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -o keyhunt keyhunt_legacy.cpp base58.o bloom.o oldbloom.o xxhash.o util.o Int.o  Point.o GMP256K1.o  IntMod.o  IntGroup.o Random.o hashing.o sha3.o keccak.o -lm -lpthread -lcrypto -lgmp	
-	rm -r *.o
+>g++ $(CXXFLAGS) -flto -c oldbloom/bloom.cpp -o oldbloom.o
+>g++ $(CXXFLAGS) -flto -c bloom/bloom.cpp -o bloom.o
+>gcc $(CFLAGS) -Wno-unused-result -c base58/base58.c -o base58.o
+>gcc $(CFLAGS) -c xxhash/xxhash.c -o xxhash.o
+>g++ $(CXXFLAGS) -c util.c -o util.o
+>g++ $(CXXFLAGS) -c sha3/sha3.c -o sha3.o
+>g++ $(CXXFLAGS) -c sha3/keccak.c -o keccak.o
+>g++ $(CXXFLAGS) -c hashing.c -o hashing.o
+>g++ $(CXXFLAGS) -c gmp256k1/Int.cpp -o Int.o
+>g++ $(CXXFLAGS) -c gmp256k1/Point.cpp -o Point.o
+>g++ $(CXXFLAGS) -c gmp256k1/GMP256K1.cpp -o GMP256K1.o
+>g++ $(CXXFLAGS) -c gmp256k1/IntMod.cpp -o IntMod.o
+>g++ $(CXXFLAGS) -flto -c gmp256k1/Random.cpp -o Random.o
+>g++ $(CXXFLAGS) -flto -c gmp256k1/IntGroup.cpp -o IntGroup.o
+>g++ $(CXXFLAGS) -o keyhunt keyhunt_legacy.cpp base58.o bloom.o oldbloom.o xxhash.o util.o Int.o Point.o GMP256K1.o IntMod.o IntGroup.o Random.o hashing.o sha3.o keccak.o -lm -lpthread -lcrypto -lgmp
+>rm -r *.o
+
 bsgsd:
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c oldbloom/bloom.cpp -o oldbloom.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c bloom/bloom.cpp -o bloom.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-unused-parameter -Ofast -ftree-vectorize -c base58/base58.c -o base58.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Ofast -ftree-vectorize -c rmd160/rmd160.c -o rmd160.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c sha3/sha3.c -o sha3.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c sha3/keccak.c -o keccak.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Ofast -ftree-vectorize -c xxhash/xxhash.c -o xxhash.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c util.c -o util.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Int.cpp -o Int.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Point.cpp -o Point.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/SECP256K1.cpp -o SECP256K1.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/IntMod.cpp -o IntMod.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c secp256k1/Random.cpp -o Random.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c secp256k1/IntGroup.cpp -o IntGroup.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/ripemd160.o -ftree-vectorize -flto -c hash/ripemd160.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256.o -ftree-vectorize -flto -c hash/sha256.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/ripemd160_sse.o -ftree-vectorize -flto -c hash/ripemd160_sse.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256_sse.o -ftree-vectorize -flto -c hash/sha256_sse.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -o bsgsd bsgsd.cpp base58.o rmd160.o hash/ripemd160.o hash/ripemd160_sse.o hash/sha256.o hash/sha256_sse.o bloom.o oldbloom.o xxhash.o util.o Int.o  Point.o SECP256K1.o  IntMod.o  Random.o IntGroup.o sha3.o keccak.o  -lm -lpthread
-	rm -r *.o
+>g++ $(CXXFLAGS) -flto -c oldbloom/bloom.cpp -o oldbloom.o
+>g++ $(CXXFLAGS) -flto -c bloom/bloom.cpp -o bloom.o
+>gcc $(CFLAGS) -Wno-unused-parameter -c base58/base58.c -o base58.o
+>gcc $(CFLAGS) -c rmd160/rmd160.c -o rmd160.o
+>g++ $(CXXFLAGS) -c sha3/sha3.c -o sha3.o
+>g++ $(CXXFLAGS) -c sha3/keccak.c -o keccak.o
+>gcc $(CFLAGS) -c xxhash/xxhash.c -o xxhash.o
+>g++ $(CXXFLAGS) -c util.c -o util.o
+>g++ $(CXXFLAGS) -c secp256k1/Int.cpp -o Int.o
+>g++ $(CXXFLAGS) -c secp256k1/Point.cpp -o Point.o
+>g++ $(CXXFLAGS) -c secp256k1/SECP256K1.cpp -o SECP256K1.o
+>g++ $(CXXFLAGS) -c secp256k1/IntMod.cpp -o IntMod.o
+>g++ $(CXXFLAGS) -flto -c secp256k1/Random.cpp -o Random.o
+>g++ $(CXXFLAGS) -flto -c secp256k1/IntGroup.cpp -o IntGroup.o
+>g++ $(CXXFLAGS) -flto -c hash/ripemd160.cpp -o hash/ripemd160.o
+>g++ $(CXXFLAGS) -flto -c hash/sha256.cpp -o hash/sha256.o
+ifneq ($(ARCH),aarch64)
+>g++ $(CXXFLAGS) -flto -c hash/ripemd160_sse.cpp -o hash/ripemd160_sse.o
+>g++ $(CXXFLAGS) -flto -c hash/sha256_sse.cpp -o hash/sha256_sse.o
+endif
+>g++ $(CXXFLAGS) -o bsgsd bsgsd.cpp base58.o rmd160.o $(HASH_OBJS) bloom.o oldbloom.o xxhash.o util.o Int.o Point.o SECP256K1.o IntMod.o Random.o IntGroup.o sha3.o keccak.o -lm -lpthread
+>rm -r *.o
+

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ First compile:
 make
 ```
 
+On ARM64 (`aarch64`) hosts the Makefile automatically sets `-march=armv8-a -mtune=generic`
+and uses the portable `hash/ripemd160.cpp` and `hash/sha256.cpp` implementations, skipping
+the SSE-specific sources.
+
 if you have problems compiling the `main` version you can compile the `legacy` version
 
 ```


### PR DESCRIPTION
## Summary
- detect aarch64 and disable SSE builds
- compile portable SHA256 and RIPEMD160 on arm64 with armv8-a flags
- document arm64 build behavior

## Testing
- `make`
- `make bsgsd`


------
https://chatgpt.com/codex/tasks/task_e_6897b95b62e4832e9d3edd912b6b1cc8