### PR TITLE
Add NEON fallbacks for SHA256 and RIPEMD160

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ARCH := $(shell uname -m)
 
 ifeq ($(ARCH),aarch64)
 ARCH_FLAGS := -march=armv8-a -mtune=generic
-HASH_OBJS := hash/ripemd160.o hash/sha256.o
+HASH_OBJS := hash/ripemd160.o hash/sha256.o hash/ripemd160_neon.o hash/sha256_neon.o
 else
 ARCH_FLAGS := -m64 -march=native -mtune=native -mssse3
 HASH_OBJS := hash/ripemd160.o hash/sha256.o hash/ripemd160_sse.o hash/sha256_sse.o
@@ -30,7 +30,10 @@ default:
 >g++ $(CXXFLAGS) -flto -c secp256k1/IntGroup.cpp -o IntGroup.o
 >g++ $(CXXFLAGS) -flto -c hash/ripemd160.cpp -o hash/ripemd160.o
 >g++ $(CXXFLAGS) -flto -c hash/sha256.cpp -o hash/sha256.o
-ifneq ($(ARCH),aarch64)
+ifeq ($(ARCH),aarch64)
+>g++ $(CXXFLAGS) -flto -c hash/ripemd160_neon.cpp -o hash/ripemd160_neon.o
+>g++ $(CXXFLAGS) -flto -c hash/sha256_neon.cpp -o hash/sha256_neon.o
+else
 >g++ $(CXXFLAGS) -flto -c hash/ripemd160_sse.cpp -o hash/ripemd160_sse.o
 >g++ $(CXXFLAGS) -flto -c hash/sha256_sse.cpp -o hash/sha256_sse.o
 endif
@@ -75,7 +78,10 @@ bsgsd:
 >g++ $(CXXFLAGS) -flto -c secp256k1/IntGroup.cpp -o IntGroup.o
 >g++ $(CXXFLAGS) -flto -c hash/ripemd160.cpp -o hash/ripemd160.o
 >g++ $(CXXFLAGS) -flto -c hash/sha256.cpp -o hash/sha256.o
-ifneq ($(ARCH),aarch64)
+ifeq ($(ARCH),aarch64)
+>g++ $(CXXFLAGS) -flto -c hash/ripemd160_neon.cpp -o hash/ripemd160_neon.o
+>g++ $(CXXFLAGS) -flto -c hash/sha256_neon.cpp -o hash/sha256_neon.o
+else
 >g++ $(CXXFLAGS) -flto -c hash/ripemd160_sse.cpp -o hash/ripemd160_sse.o
 >g++ $(CXXFLAGS) -flto -c hash/sha256_sse.cpp -o hash/sha256_sse.o
 endif

--- a/hash/ripemd160.h
+++ b/hash/ripemd160.h
@@ -41,9 +41,16 @@ public:
 
 void ripemd160(unsigned char *input,int length,unsigned char *digest);
 void ripemd160_32(unsigned char *input, unsigned char *digest);
+#if defined(__x86_64__) || defined(__SSE__)
 void ripemd160sse_32(uint8_t *i0, uint8_t *i1, uint8_t *i2, uint8_t *i3,
   uint8_t *d0, uint8_t *d1, uint8_t *d2, uint8_t *d3);
 void ripemd160sse_test();
+#define ripemd160_simd_32 ripemd160sse_32
+#elif defined(__aarch64__) || defined(__ARM_NEON)
+void ripemd160neon_32(uint8_t *i0, uint8_t *i1, uint8_t *i2, uint8_t *i3,
+  uint8_t *d0, uint8_t *d1, uint8_t *d2, uint8_t *d3);
+#define ripemd160_simd_32 ripemd160neon_32
+#endif
 std::string ripemd160_hex(unsigned char *digest);
 
 static inline bool ripemd160_comp_hash(uint8_t *h0, uint8_t *h1) {

--- a/hash/ripemd160_neon.cpp
+++ b/hash/ripemd160_neon.cpp
@@ -1,0 +1,22 @@
+#include "ripemd160.h"
+
+// Sequential fallback/NEON-friendly implementation processing
+// four independent 32-byte messages using the generic RIPEMD160
+// routine. This file is used on ARM/NEON or other targets where
+// SSE is unavailable.
+void ripemd160neon_32(
+  unsigned char *i0,
+  unsigned char *i1,
+  unsigned char *i2,
+  unsigned char *i3,
+  unsigned char *d0,
+  unsigned char *d1,
+  unsigned char *d2,
+  unsigned char *d3)
+{
+  ripemd160_32(i0, d0);
+  ripemd160_32(i1, d1);
+  ripemd160_32(i2, d2);
+  ripemd160_32(i3, d3);
+}
+

--- a/hash/sha256.h
+++ b/hash/sha256.h
@@ -28,12 +28,27 @@ void sha256_33(uint8_t *input, uint8_t *digest);
 void sha256_65(uint8_t *input, uint8_t *digest);
 void sha256_checksum(uint8_t *input, int length, uint8_t *checksum);
 bool sha256_file(const char* file_name, uint8_t* checksum);
+#if defined(__x86_64__) || defined(__SSE__)
 void sha256sse_1B(uint32_t *i0, uint32_t *i1, uint32_t *i2, uint32_t *i3,
   uint8_t *d0, uint8_t *d1, uint8_t *d2, uint8_t *d3);
 void sha256sse_2B(uint32_t *i0, uint32_t *i1, uint32_t *i2, uint32_t *i3,
   uint8_t *d0, uint8_t *d1, uint8_t *d2, uint8_t *d3);
 void sha256sse_checksum(uint32_t *i0, uint32_t *i1, uint32_t *i2, uint32_t *i3,
   uint8_t *d0, uint8_t *d1, uint8_t *d2, uint8_t *d3);
+#define sha256_simd_1B sha256sse_1B
+#define sha256_simd_2B sha256sse_2B
+#define sha256_simd_checksum sha256sse_checksum
+#elif defined(__aarch64__) || defined(__ARM_NEON)
+void sha256neon_1B(uint32_t *i0, uint32_t *i1, uint32_t *i2, uint32_t *i3,
+  uint8_t *d0, uint8_t *d1, uint8_t *d2, uint8_t *d3);
+void sha256neon_2B(uint32_t *i0, uint32_t *i1, uint32_t *i2, uint32_t *i3,
+  uint8_t *d0, uint8_t *d1, uint8_t *d2, uint8_t *d3);
+void sha256neon_checksum(uint32_t *i0, uint32_t *i1, uint32_t *i2, uint32_t *i3,
+  uint8_t *d0, uint8_t *d1, uint8_t *d2, uint8_t *d3);
+#define sha256_simd_1B sha256neon_1B
+#define sha256_simd_2B sha256neon_2B
+#define sha256_simd_checksum sha256neon_checksum
+#endif
 std::string sha256_hex(unsigned char *digest);
 void sha256sse_test();
 

--- a/hash/sha256_neon.cpp
+++ b/hash/sha256_neon.cpp
@@ -1,0 +1,53 @@
+#include "sha256.h"
+
+// Sequential fallback/NEON-friendly implementation processing
+// four independent messages using the generic SHA-256 routine.
+// Each input block is expected to be already padded.
+void sha256neon_1B(
+  uint32_t *i0,
+  uint32_t *i1,
+  uint32_t *i2,
+  uint32_t *i3,
+  unsigned char *d0,
+  unsigned char *d1,
+  unsigned char *d2,
+  unsigned char *d3)
+{
+  sha256((unsigned char*)i0, 64, d0);
+  sha256((unsigned char*)i1, 64, d1);
+  sha256((unsigned char*)i2, 64, d2);
+  sha256((unsigned char*)i3, 64, d3);
+}
+
+void sha256neon_2B(
+  uint32_t *i0,
+  uint32_t *i1,
+  uint32_t *i2,
+  uint32_t *i3,
+  unsigned char *d0,
+  unsigned char *d1,
+  unsigned char *d2,
+  unsigned char *d3)
+{
+  sha256((unsigned char*)i0, 128, d0);
+  sha256((unsigned char*)i1, 128, d1);
+  sha256((unsigned char*)i2, 128, d2);
+  sha256((unsigned char*)i3, 128, d3);
+}
+
+void sha256neon_checksum(
+  uint32_t *i0,
+  uint32_t *i1,
+  uint32_t *i2,
+  uint32_t *i3,
+  uint8_t *d0,
+  uint8_t *d1,
+  uint8_t *d2,
+  uint8_t *d3)
+{
+  sha256_checksum((uint8_t*)i0, 32, d0);
+  sha256_checksum((uint8_t*)i1, 32, d1);
+  sha256_checksum((uint8_t*)i2, 32, d2);
+  sha256_checksum((uint8_t*)i3, 32, d3);
+}
+

--- a/keyhunt.cpp
+++ b/keyhunt.cpp
@@ -5966,7 +5966,7 @@ void sha256sse_22(uint8_t *src0, uint8_t *src1, uint8_t *src2, uint8_t *src3, ui
   BUFFMINIKEY(b1, src1);
   BUFFMINIKEY(b2, src2);
   BUFFMINIKEY(b3, src3);
-  sha256sse_1B(b0, b1, b2, b3, dst0, dst1, dst2, dst3);
+  sha256_simd_1B(b0, b1, b2, b3, dst0, dst1, dst2, dst3);
 }
 
 
@@ -5997,7 +5997,7 @@ void sha256sse_23(uint8_t *src0, uint8_t *src1, uint8_t *src2, uint8_t *src3, ui
   BUFFMINIKEYCHECK(b1, src1);
   BUFFMINIKEYCHECK(b2, src2);
   BUFFMINIKEYCHECK(b3, src3);
-  sha256sse_1B(b0, b1, b2, b3, dst0, dst1, dst2, dst3);
+  sha256_simd_1B(b0, b1, b2, b3, dst0, dst1, dst2, dst3);
 }
 
 void menu() {

--- a/secp256k1/SECP256K1.cpp
+++ b/secp256k1/SECP256K1.cpp
@@ -615,8 +615,8 @@ void Secp256K1::GetHash160(int type,bool compressed,
       KEYBUFFUNCOMP(b2, k2);
       KEYBUFFUNCOMP(b3, k3);
 
-      sha256sse_2B(b0, b1, b2, b3, sh0, sh1, sh2, sh3);
-      ripemd160sse_32(sh0, sh1, sh2, sh3, h0, h1, h2, h3);
+      sha256_simd_2B(b0, b1, b2, b3, sh0, sh1, sh2, sh3);
+      ripemd160_simd_32(sh0, sh1, sh2, sh3, h0, h1, h2, h3);
 
     } else {
 
@@ -630,8 +630,8 @@ void Secp256K1::GetHash160(int type,bool compressed,
       KEYBUFFCOMP(b2, k2);
       KEYBUFFCOMP(b3, k3);
 
-      sha256sse_1B(b0, b1, b2, b3, sh0, sh1, sh2, sh3);
-      ripemd160sse_32(sh0, sh1, sh2, sh3, h0, h1, h2, h3);
+      sha256_simd_1B(b0, b1, b2, b3, sh0, sh1, sh2, sh3);
+      ripemd160_simd_32(sh0, sh1, sh2, sh3, h0, h1, h2, h3);
 
     }
 
@@ -659,8 +659,8 @@ void Secp256K1::GetHash160(int type,bool compressed,
     KEYBUFFSCRIPT(b2, kh2);
     KEYBUFFSCRIPT(b3, kh3);
 
-    sha256sse_1B(b0, b1, b2, b3, sh0, sh1, sh2, sh3);
-    ripemd160sse_32(sh0, sh1, sh2, sh3, h0, h1, h2, h3);
+    sha256_simd_1B(b0, b1, b2, b3, sh0, sh1, sh2, sh3);
+    ripemd160_simd_32(sh0, sh1, sh2, sh3, h0, h1, h2, h3);
 
   }
   break;
@@ -773,8 +773,8 @@ void Secp256K1::GetHash160_fromX(int type,unsigned char prefix,
       KEYBUFFPREFIX(b2, k2, prefix);
       KEYBUFFPREFIX(b3, k3, prefix);
 
-      sha256sse_1B(b0, b1, b2, b3, sh0, sh1, sh2, sh3);
-      ripemd160sse_32(sh0, sh1, sh2, sh3, h0, h1, h2, h3);
+      sha256_simd_1B(b0, b1, b2, b3, sh0, sh1, sh2, sh3);
+      ripemd160_simd_32(sh0, sh1, sh2, sh3, h0, h1, h2, h3);
   }
   break;
 


### PR DESCRIPTION
## Summary
- add pure C/NEON implementations for RIPEMD160 and SHA256
- use architecture macros to select SSE or NEON hashing backends
- build scripts compile the appropriate hash implementation per platform

## Testing
- `make -C /workspace/keyhunt`
- `g++ -std=c++11 -I. /tmp/hash_test.cpp hash/sha256_neon.cpp hash/ripemd160_neon.cpp hash/sha256.cpp hash/ripemd160.cpp -o /tmp/hash_test`
- `/tmp/hash_test`
- `g++ -std=c++11 -I. /tmp/ripemd_test.cpp hash/ripemd160_sse.cpp hash/ripemd160.cpp -o /tmp/ripemd_test`
- `/tmp/ripemd_test`


------
https://chatgpt.com/codex/tasks/task_e_6897bc678054832e8c5d11861a17afe6