### PR TITLE
Add ARM compile-time check for SSE2

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -1,0 +1,15 @@
+name: arm-build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  no-sse2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cross compiler
+        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
+      - name: Compile xxhash without SSE2
+        run: aarch64-linux-gnu-gcc -I. -march=armv8-a -mtune=generic tests/no_sse2.c -c

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ARCH := $(shell uname -m)
 
 ifeq ($(ARCH),aarch64)
-ARCH_FLAGS := -march=armv8-a -mtune=generic
+ARCH_FLAGS := -march=armv8-a -mtune=generic -U__SSE2__
 HASH_OBJS := hash/ripemd160.o hash/sha256.o hash/ripemd160_neon.o hash/sha256_neon.o
 else
 ARCH_FLAGS := -m64 -march=native -mtune=native -mssse3

--- a/tests/no_sse2.c
+++ b/tests/no_sse2.c
@@ -1,0 +1,5 @@
+#include "xxhash/xxhash.h"
+#ifdef __SSE2__
+#error "__SSE2__ defined for ARM build"
+#endif
+int main(void) { return 0; }


### PR DESCRIPTION
## Summary
- explicitly undefine `__SSE2__` for ARM builds to avoid `<emmintrin.h>`
- add a compile-time test verifying `xxhash.h` is built without SSE2
- run the test in CI using an ARM cross-compiler

## Testing
- `make`
- `aarch64-linux-gnu-gcc -I. -march=armv8-a -mtune=generic tests/no_sse2.c -c`

------
https://chatgpt.com/codex/tasks/task_e_6897d8294fc0832ebaa359edc82556fd