### PR TITLE
Ensure base58 buffer is initialized and add tests

### DIFF
--- a/base58/base58.c
+++ b/base58/base58.c
@@ -41,21 +41,18 @@ bool b58tobin(void *bin, size_t *binszp, const char *b58, size_t b58sz)
 	size_t binsz = *binszp;
 	const unsigned char *b58u = (void*)b58;
 	unsigned char *binu = bin;
-	size_t outisz = (binsz + sizeof(b58_almostmaxint_t) - 1) / sizeof(b58_almostmaxint_t);
-	b58_almostmaxint_t outi[outisz];
-	b58_maxint_t t;
-	b58_almostmaxint_t c;
-	size_t i, j;
-	uint8_t bytesleft = binsz % sizeof(b58_almostmaxint_t);
-	b58_almostmaxint_t zeromask = bytesleft ? (b58_almostmaxint_mask << (bytesleft * 8)) : 0;
-	unsigned zerocount = 0;
-	
-	if (!b58sz)
-		b58sz = strlen(b58);
-	
-	for (i = 0; i < outisz; ++i) {
-		outi[i] = 0;
-	}
+        size_t outisz = (binsz + sizeof(b58_almostmaxint_t) - 1) / sizeof(b58_almostmaxint_t);
+        b58_almostmaxint_t outi[outisz ? outisz : 1];
+        memset(outi, 0, sizeof(outi));
+        b58_maxint_t t;
+        b58_almostmaxint_t c;
+        size_t i, j;
+        uint8_t bytesleft = binsz % sizeof(b58_almostmaxint_t);
+        b58_almostmaxint_t zeromask = bytesleft ? (b58_almostmaxint_mask << (bytesleft * 8)) : 0;
+        unsigned zerocount = 0;
+
+        if (!b58sz)
+                b58sz = strlen(b58);
 	
 	// Leading zeros, just count
 	for (i = 0; i < b58sz && b58u[i] == '1'; ++i)

--- a/hash/ripemd160.cpp
+++ b/hash/ripemd160.cpp
@@ -36,12 +36,9 @@ void inline Initialize(uint32_t* s)
     s[4] = 0xC3D2E1F0ul;
 }
 
-#ifndef WIN64
 inline uint32_t _rotl(uint32_t x, uint8_t r) {
-  asm("roll %1,%0" : "+r" (x) : "c" (r));
-  return x;
+  return (x << r) | (x >> (32 - r));
 }
-#endif
 
 #define ROL(x,n) _rotl(x,n)
 

--- a/hash/sha256.cpp
+++ b/hash/sha256.cpp
@@ -34,11 +34,11 @@ namespace _sha256
 #ifndef WIN64
 #define _byteswap_ulong __builtin_bswap32
 #define _byteswap_uint64 __builtin_bswap64
-inline uint32_t _rotr(uint32_t x, uint8_t r) {
-  asm("rorl %1,%0" : "+r" (x) : "c" (r));
-  return x;
-}
 #endif
+
+inline uint32_t _rotr(uint32_t x, uint8_t r) {
+  return (x >> r) | (x << (32 - r));
+}
 
 #define ROR(x,n) _rotr(x, n)
 #define S0(x) (ROR(x,2) ^ ROR(x,13) ^ ROR(x,22))

--- a/hash/sha512.cpp
+++ b/hash/sha512.cpp
@@ -60,11 +60,11 @@ namespace _sha512 {
 #ifndef WIN64
 #define _byteswap_ulong __builtin_bswap32
 #define _byteswap_uint64 __builtin_bswap64
-inline uint64_t _rotr64(uint64_t x, uint8_t r) {
-  asm("rorq %1,%0" : "+r" (x) : "c" (r));
-  return x;
-}
 #endif
+
+inline uint64_t _rotr64(uint64_t x, uint8_t r) {
+  return (x >> r) | (x << (64 - r));
+}
 
 #define ROR(x,n) _rotr64(x, n)
 #define S0(x)		(ROR(x, 28) ^ ROR(x, 34) ^ ROR(x, 39))

--- a/tests/test_b58tobin.c
+++ b/tests/test_b58tobin.c
@@ -1,0 +1,30 @@
+#include <assert.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "../base58/libbase58.h"
+
+static void roundtrip(const unsigned char *data, size_t len) {
+    char b58[128];
+    size_t b58sz = sizeof(b58);
+    assert(b58enc(b58, &b58sz, data, len));
+
+    unsigned char out[128];
+    size_t outsz = len;
+    assert(b58tobin(out, &outsz, b58, b58sz - 1));
+    assert(outsz == len);
+    assert(memcmp(out, data, len) == 0);
+}
+
+int main(void) {
+    const unsigned char d1[] = {0x01};
+    const unsigned char d2[] = {0x01, 0x02};
+    const unsigned char d3[] = {0x01, 0x02, 0x03};
+    const unsigned char d5[] = {0x00, 0x01, 0x02, 0x03, 0x04};
+
+    roundtrip(d1, sizeof(d1));
+    roundtrip(d2, sizeof(d2));
+    roundtrip(d3, sizeof(d3));
+    roundtrip(d5, sizeof(d5));
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Prevent undefined reads by fully zero-initializing the `outi` buffer in `b58tobin`
- Add unit tests exercising `bytesleft`-driven decoding paths in the base58 library
- Replace x86 inline rotation asm in hash implementations with portable C

## Testing
- `gcc -std=c11 -Wall -Wextra -fsanitize=address,undefined tests/test_b58tobin.c base58/base58.c -o tests/test_b58tobin && ./tests/test_b58tobin`
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_6897c3203c18832ebf9f692f7b478919