### PR TITLE
Add configurable mmap prefetch controls and IO logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,12 @@ supplied, keyhunt stores this table in a temporary file and maps it into
 memory. Use `--ptable=<file>` or `--ptable <file>` to select the backing file
 path and `--ptable-size <size>` preallocates it (accepting `K`, `M`, `G` and `T`
 suffixes). The mapped table is flushed on shutdown and the temporary file is
-removed unless a path was explicitly provided. To reuse an existing bP table,
-combine `--load-ptable` with `--ptable`. By default the file is created in the
-system temporary directory; use `--tmpdir <dir>` or set `TEMP`/`TMPDIR` to
-choose a different location.
+removed unless a path was explicitly provided. By default the file is created
+as a sparse allocation via `ftruncate`; use `--ptable-prealloc fallocate` if
+you explicitly want on-disk preallocation (which can be slow for large files).
+To reuse an existing bP table, combine `--load-ptable` with `--ptable`. By
+default the file is created in the system temporary directory; use `--tmpdir
+<dir>` or set `TEMP`/`TMPDIR` to choose a different location.
 
 ## Free Code
 

--- a/bloom/bloom.cpp
+++ b/bloom/bloom.cpp
@@ -35,6 +35,26 @@
 #define BLOOM_VERSION_MAJOR 2
 #define BLOOM_VERSION_MINOR 201
 
+int bloom_global_populate = 0;
+int bloom_global_willneed = 0;
+
+static inline int bloom_map_flags()
+{
+  int map_flags = MAP_SHARED;
+  if (bloom_global_populate) {
+#ifdef MAP_POPULATE
+    map_flags |= MAP_POPULATE;
+#else
+    static int warned = 0;
+    if (!warned) {
+      warned = 1;
+      fprintf(stderr, "[i] bloom: MAP_POPULATE not supported; skipping\n");
+    }
+#endif
+  }
+  return map_flags;
+}
+
 inline static int test_bit_set_bit(struct bloom *bloom, uint64_t bit, int set_bit)
 {
   uint64_t byte = bit >> 3;
@@ -84,28 +104,44 @@ inline static int test_bit(struct bloom *bloom, uint64_t bit)
 
 #if !defined(_WIN64)
 static inline void bloom_advise_fd(int fd, off_t length) {
+  if (fd < 0 || length <= 0) {
+    return;
+  }
 #if defined(POSIX_FADV_SEQUENTIAL)
-  if (fd >= 0) {
-    posix_fadvise(fd, 0, length, POSIX_FADV_SEQUENTIAL);
-  }
+  posix_fadvise(fd, 0, length, POSIX_FADV_SEQUENTIAL);
 #endif
+  extern int bloom_global_willneed;
+  if (bloom_global_willneed) {
 #if defined(POSIX_FADV_WILLNEED)
-  if (fd >= 0) {
     posix_fadvise(fd, 0, length, POSIX_FADV_WILLNEED);
-  }
+#else
+    static int warned = 0;
+    if (!warned) {
+      warned = 1;
+      fprintf(stderr, "[i] bloom: POSIX_FADV_WILLNEED not supported; skipping\n");
+    }
 #endif
+  }
 }
 
 static inline void bloom_advise_map(void *addr, size_t length) {
+  if (!addr || length == 0) {
+    return;
+  }
+  extern int bloom_global_willneed;
+  if (bloom_global_willneed) {
 #if defined(MADV_WILLNEED)
-  if (addr && length) {
     madvise(addr, length, MADV_WILLNEED);
-  }
+#else
+    static int warned = 0;
+    if (!warned) {
+      warned = 1;
+      fprintf(stderr, "[i] bloom: MADV_WILLNEED not supported; skipping\n");
+    }
 #endif
-#if defined(MADV_SEQUENTIAL)
-  if (addr && length) {
-    madvise(addr, length, MADV_SEQUENTIAL);
   }
+#if defined(MADV_SEQUENTIAL)
+  madvise(addr, length, MADV_SEQUENTIAL);
 #endif
 }
 #endif
@@ -373,10 +409,7 @@ int bloom_load(struct bloom * bloom, char * filename)
         int cfd = open(fname, O_RDWR);
         if (cfd < 0) { rv = 11; goto load_error_chunks; }
         bloom_advise_fd(cfd, (off_t)cbytes);
-        int map_flags = MAP_SHARED;
-#ifdef MAP_POPULATE
-        map_flags |= MAP_POPULATE;
-#endif
+        int map_flags = bloom_map_flags();
         uint8_t *map = (uint8_t*)mmap(NULL, cbytes, PROT_READ | PROT_WRITE, map_flags, cfd, 0);
         close(cfd);
         if (map == MAP_FAILED) { rv = 12; goto load_error_chunks; }
@@ -389,10 +422,7 @@ int bloom_load(struct bloom * bloom, char * filename)
       int cfd = open(filename, O_RDWR);
       if (cfd < 0) { rv = 11; goto load_error; }
       bloom_advise_fd(cfd, (off_t)bloom->bytes);
-      int map_flags = MAP_SHARED;
-#ifdef MAP_POPULATE
-      map_flags |= MAP_POPULATE;
-#endif
+      int map_flags = bloom_map_flags();
       uint8_t *map = (uint8_t*)mmap(NULL, bloom->bytes, PROT_READ | PROT_WRITE, map_flags, cfd, offset);
       close(cfd);
       if (map == MAP_FAILED) { rv = 12; goto load_error; }
@@ -486,6 +516,16 @@ void bloom_set_readonly(int readonly)
   bloom_readonly_mode = readonly ? 1 : 0;
 }
 
+void bloom_set_populate(int populate)
+{
+  bloom_global_populate = populate ? 1 : 0;
+}
+
+void bloom_set_willneed(int willneed)
+{
+  bloom_global_willneed = willneed ? 1 : 0;
+}
+
 int bloom_load_mmap(struct bloom *bloom, const char *filename, uint32_t chunks)
 {
   if (!bloom || !filename) {
@@ -528,10 +568,7 @@ int bloom_load_mmap(struct bloom *bloom, const char *filename, uint32_t chunks)
     }
     uint64_t cbytes = (uint64_t)st.st_size;
     bloom_advise_fd(fd, (off_t)cbytes);
-    int map_flags = MAP_SHARED;
-#ifdef MAP_POPULATE
-    map_flags |= MAP_POPULATE;
-#endif
+    int map_flags = bloom_map_flags();
     int prot_flags = bloom_readonly_mode ? PROT_READ : (PROT_READ | PROT_WRITE);
     uint8_t *map = (uint8_t*)mmap(NULL, cbytes, prot_flags, map_flags, fd, 0);
     close(fd);
@@ -695,10 +732,7 @@ int bloom_init_mmap(struct bloom *bloom, uint64_t entries, long double error, co
     }
 
     bloom_advise_fd(fd, (off_t)cbytes);
-    int map_flags = MAP_SHARED;
-#ifdef MAP_POPULATE
-    map_flags |= MAP_POPULATE;
-#endif
+    int map_flags = bloom_map_flags();
     int prot_flags = bloom_readonly_mode ? PROT_READ : (PROT_READ | PROT_WRITE);
     uint8_t *map = (uint8_t*)mmap(NULL, cbytes, prot_flags, map_flags, fd, 0);
     if (map == MAP_FAILED) {

--- a/bloom/bloom.h
+++ b/bloom/bloom.h
@@ -224,6 +224,8 @@ int bloom_init_mmap(struct bloom * bloom, uint64_t entries, long double error, c
 int bloom_load_mmap(struct bloom * bloom, const char *filename, uint32_t chunks);
 void bloom_unmap(struct bloom * bloom);
 void bloom_set_readonly(int readonly);
+void bloom_set_populate(int populate);
+void bloom_set_willneed(int willneed);
 
 #ifdef __cplusplus
 }

--- a/tests/test_help_output.sh
+++ b/tests/test_help_output.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/keyhunt"
+if [[ ! -x "$BIN" ]]; then
+  echo "keyhunt binary not found at $BIN; build the project first" >&2
+  exit 1
+fi
+out="$($BIN -h 2>&1)"
+required=("--mapped" "--mapped-plan" "--mapped-populate" "--mapped-willneed" \
+  "--bloom-bytes" "--ptable" "--ptable-prealloc" "--load-ptable" "--io-verbose")
+for flag in "${required[@]}"; do
+  if ! grep -q "$flag" <<<"$out"; then
+    echo "missing flag in help: $flag" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
## Summary
- switch mapped bloom and ptable handling to be lazy by default, with optional MAP_POPULATE/MADV_WILLNEED and posix_fallocate preallocation knobs
- add IO timing/logging hooks plus help text for the new mapping controls and sparse ptable creation
- include a help-output regression script to ensure legacy flags stay visible alongside the new options

## Flags verified from `-h`
- Existing: --mapped, --mapped-plan, --bloom-bytes, --ptable, --load-ptable
- New: --mapped-populate, --mapped-willneed, --ptable-prealloc, --io-verbose

## Testing
- make -j2
- tests/test_help_output.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae2b4d67c832eac2e628cdf3431b8)