### PR TITLE
Add distributed worker flags for mapped BSGS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ same parameters plus distinct `--bsgs-worker-id` values (0-indexed) and set
 Use `--skip-bsgs-finalize` on the workers that should only generate their
 assigned slice; run one final pass without that flag after all workers finish
 so the shared bP table is sorted and its checksums are refreshed.
+Workers with `--bsgs-worker-id > 0` refuse to truncate/allocate the shared
+files and require worker 0 (or a dedicated coordinator run) to create the
+mapped bloom shards and ptable beforehand.
 
 ## Free Code
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ To reuse an existing bP table, combine `--load-ptable` with `--ptable`. By
 default the file is created in the system temporary directory; use `--tmpdir
 <dir>` or set `TEMP`/`TMPDIR` to choose a different location.
 
+### Distributed precomputation
+
+When your bloom shards and bP table live on a shared filesystem, you can split
+the baby-step generation across multiple hosts. Provide each worker with the
+same parameters plus distinct `--bsgs-worker-id` values (0-indexed) and set
+`--bsgs-worker-total` to the total worker count. Point `--mapped` and
+`--ptable` at the shared paths so every worker contributes to the same files.
+Use `--skip-bsgs-finalize` on the workers that should only generate their
+assigned slice; run one final pass without that flag after all workers finish
+so the shared bP table is sorted and its checksums are refreshed.
+
 ## Free Code
 
 This code is free of charge, see the licence for more details. https://github.com/albertobsd/keyhunt/blob/main/LICENSE


### PR DESCRIPTION
## Summary
- add `--bsgs-worker-id/--bsgs-worker-total` flags to partition mapped bloom/ptable generation across multiple hosts
- allow workers to skip finalization while writing their slice into shared mapped files and print their assigned ranges
- document the distributed workflow in the README

## Testing
- make -j2


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695abb28d308832e86869d20763ede95)