### PR TITLE
Support worker-specific ptable slices

### DIFF
--- a/util.c
+++ b/util.c
@@ -170,6 +170,17 @@ int md5_file(const char *path, uint8_t digest[16]) {
         return 0;
 }
 
+int md5_buffer(const uint8_t *data, size_t len, uint8_t digest[16]) {
+        if (!data || !digest) {
+                return -1;
+        }
+        md5_ctx ctx;
+        md5_init(&ctx);
+        md5_update(&ctx, data, len);
+        md5_final(&ctx, digest);
+        return 0;
+}
+
 void md5_to_hex(const uint8_t digest[16], char hex[33]) {
         static const char hexdigits[] = "0123456789abcdef";
         if (!digest || !hex) {

--- a/util.h
+++ b/util.h
@@ -1,6 +1,7 @@
 #ifndef CUSTOMUTILH
 #define CUSTOMUTILH
 
+#include <stddef.h>
 #include <stdint.h>
 typedef struct str_list	{
 	int n;
@@ -37,6 +38,7 @@ void print_nk_table(void);
 uint64_t get_total_ram(void);
 
 int md5_file(const char *path, uint8_t digest[16]);
+int md5_buffer(const uint8_t *data, size_t len, uint8_t digest[16]);
 void md5_to_hex(const uint8_t digest[16], char hex[33]);
 
 #endif // CUSTOMUTILH


### PR DESCRIPTION
## Summary
- add a worker-total option and compute per-worker slice offsets for the bP table
- allocate/map only the local slice, hash the slice contents, and emit worker metadata describing the range
- add an in-memory MD5 helper for hashing mapped slices without rereading files

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af1023018832ea06dad827fbabf5e)