### PR TITLE
Fix worker directory routing for sharded BSGS builds

### DIFF
--- a/keyhunt.cpp
+++ b/keyhunt.cpp
@@ -677,17 +677,47 @@ static bool ensure_directory_exists(const std::string &dir, bool readonly) {
         return true;
 }
 
+static bool dir_component_matches_worker_id(const std::string &component, uint32_t id) {
+        if (component.empty()) {
+                return false;
+        }
+        char worker_label[32];
+        snprintf(worker_label, sizeof(worker_label), "worker%u", id);
+        if (component == worker_label) {
+                return true;
+        }
+        char padded_label[32];
+        snprintf(padded_label, sizeof(padded_label), "worker%03u", id);
+        if (component == padded_label) {
+                return true;
+        }
+        snprintf(padded_label, sizeof(padded_label), "w%u", id);
+        if (component == padded_label) {
+                return true;
+        }
+        snprintf(padded_label, sizeof(padded_label), "w%03u", id);
+        if (component == padded_label) {
+                return true;
+        }
+        return false;
+}
+
 static std::string worker_directory_for_path(const std::string &base_dir, uint32_t worker_override = std::numeric_limits<uint32_t>::max(), uint32_t total_override = std::numeric_limits<uint32_t>::max()) {
         uint32_t id = (worker_override == std::numeric_limits<uint32_t>::max()) ? worker_id : worker_override;
         uint32_t total = (total_override == std::numeric_limits<uint32_t>::max()) ? worker_total : total_override;
-        std::string dir = (worker_outdir && *worker_outdir) ? worker_outdir : base_dir;
+        bool base_dir_meaningful = !(base_dir.empty() || base_dir == "." || base_dir == "./");
+        std::string dir = base_dir_meaningful ? base_dir : "";
+        if (!base_dir_meaningful && worker_outdir && *worker_outdir) {
+                dir = worker_outdir;
+        }
         if (dir.empty()) {
                 dir = ".";
         }
         if (dir.size() > 1 && (dir.back() == '/' || dir.back() == '\\')) {
                 dir.pop_back();
         }
-        if (id > 0) {
+        bool already_worker_specific = base_dir_meaningful && dir_component_matches_worker_id(path_basename(dir), id);
+        if (id > 0 && !already_worker_specific) {
                 char worker_label[32];
                 snprintf(worker_label, sizeof(worker_label), "worker%u", id);
                 std::string last = path_basename(dir);


### PR DESCRIPTION
## Summary
- respect user-specified per-worker directories and avoid overriding them with --worker-outdir when paths are explicit
- skip adding an extra worker suffix when the provided directory already encodes the worker id (e.g., w001)
- keep existing worker subdirectory behavior when using shared roots so shard merges still locate metadata correctly

## Testing
- make -j2
- tests/test_bsgs_merge_shards.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b14250690832e8d7056ca9992d9fa)