### PR TITLE
Fix mapped bloom path resolution for worker shards

### DIFF
--- a/keyhunt.cpp
+++ b/keyhunt.cpp
@@ -8989,14 +8989,17 @@ bool initBloomFilterMapped(struct bloom *bloom_arg,uint64_t items_bloom, const c
         std::string map_path = fname ? fname : (mapped_filename ? mapped_filename : "bloom.dat");
         bool readonly = FLAGLOADBLOOM || FLAGMAPPEDREADONLY;
         if (!map_path.empty() && map_path[0] != '/' && map_path.find(":/") == std::string::npos) {
-                const char *dir_hint = NULL;
-                if (mapped_dir && *mapped_dir) {
-                        dir_hint = mapped_dir;
-                } else if (tmpdir_path && *tmpdir_path) {
-                        dir_hint = tmpdir_path;
-                }
-                if (dir_hint && *dir_hint) {
-                        map_path = std::string(dir_hint) + "/" + map_path;
+                bool has_dir_separator = (map_path.find('/') != std::string::npos) || (map_path.find('\\') != std::string::npos);
+                if (!has_dir_separator) {
+                        const char *dir_hint = NULL;
+                        if (mapped_dir && *mapped_dir) {
+                                dir_hint = mapped_dir;
+                        } else if (tmpdir_path && *tmpdir_path) {
+                                dir_hint = tmpdir_path;
+                        }
+                        if (dir_hint && *dir_hint) {
+                                map_path = std::string(dir_hint) + "/" + map_path;
+                        }
                 }
         }
         map_path = resolve_bloom_path_for_worker(map_path, readonly);

--- a/tests/test_worker_relative_mapped_paths.sh
+++ b/tests/test_worker_relative_mapped_paths.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+BIN="$ROOT_DIR/keyhunt"
+
+if [[ ! -x "$BIN" ]]; then
+  echo "keyhunt binary not found at $BIN; build the project first" >&2
+  exit 1
+fi
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+pushd "$WORKDIR" >/dev/null
+
+workers=2
+common_args=(
+  -m bsgs
+  -r 1:ffffff
+  -f "$ROOT_DIR/tests/1to63_65.txt"
+  -k 1
+  -n 0x400000
+  -q
+  -s 1
+  -t 1
+  --bsgs-block-count 1
+  --mapped
+  --mapped-chunks 1
+  --force-ptable-rebuild
+)
+
+run_worker() {
+  local wid=$1
+  local wdir="workers/w$(printf "%03d" "$wid")"
+  mkdir -p "$wdir"
+  timeout 45s "$BIN" "${common_args[@]}" \
+    --worker-total "$workers" \
+    --worker-id "$wid" \
+    --worker-outdir ./workers \
+    --mapped-dir "./${wdir}" \
+    --bloom-file "./${wdir}/bloom.dat" \
+    --ptable "./${wdir}/ptable.tbl" \
+    --bsgs-build-only \
+    >"$WORKDIR/worker_${wid}.log" 2>&1
+}
+
+for wid in $(seq 0 $((workers - 1))); do
+  run_worker "$wid"
+done
+
+for wid in $(seq 0 $((workers - 1))); do
+  wdir="$WORKDIR/workers/w$(printf "%03d" "$wid")"
+  expected="$wdir/bloom.dat.layer1-000.dat"
+  nested="$wdir/workers/w$(printf "%03d" "$wid")/bloom.dat.layer1-000.dat"
+  if [[ ! -f "$expected" ]]; then
+    echo "expected bloom shard missing at $expected" >&2
+    exit 1
+  fi
+  if [[ -f "$nested" ]]; then
+    echo "unexpected nested bloom path created at $nested" >&2
+    exit 1
+  fi
+done
+
+popd >/dev/null
+
+echo "[+] worker-relative mapped bloom paths stay in expected directories"


### PR DESCRIPTION
## Summary
- prevent mapped bloom paths from being prefixed twice when a custom bloom file already includes directories
- add a regression test that builds worker shards using relative worker-specific paths to ensure bloom files are written in the expected location

## Testing
- make -j4
- tests/test_worker_relative_mapped_paths.sh
- tests/test_bsgs_merge_shards.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b20ede9a4832ea8c4e83f92c4da7c)