### PR TITLE
Fix BSGS merge sizing and ptable conflicts

### DIFF
--- a/tests/test_bsgs_merge_mapped_size.sh
+++ b/tests/test_bsgs_merge_mapped_size.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(cd -- "${script_dir}/.." && pwd)
+cd "$repo_root"
+
+TMPDIR=$(mktemp -d)
+cleanup() {
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+build_common=(
+  -m bsgs
+  -r 1:ffffff
+  -f tests/1to63_65.txt
+  --mapped
+  --mapped-size 1M
+  --mapped-dir "$TMPDIR"
+  --tmpdir "$TMPDIR"
+  --ptable "$TMPDIR/bptable.tbl"
+  --worker-outdir "$TMPDIR"
+  --bsgs-build-only
+  -k 1
+  -n 0x400000
+  -t 1
+  -q
+  -s 1
+)
+
+# Build two worker slices with custom mapped sizing.
+./keyhunt "${build_common[@]}" --worker-id 0 --worker-total 2
+./keyhunt "${build_common[@]}" --worker-id 1 --worker-total 2
+
+# Collect metadata for merging.
+cp "$TMPDIR/worker1/bptable.tbl.worker1.meta" "$TMPDIR/"
+
+merge_cmd=(
+  ./keyhunt
+  -m bsgs
+  -f tests/1to63_65.txt
+  -r 1:ffffff
+  -n 0x400000
+  --mapped-dir "$TMPDIR"
+  --ptable "$TMPDIR/bptable.tbl"
+  --bsgs-merge-from "$TMPDIR/bptable.tbl.worker*.meta"
+  --bsgs-merge-only
+  -q
+)
+
+"${merge_cmd[@]}"
+
+worker_size=$(stat -c %s "$TMPDIR/worker1/bloom.layer1-000.dat")
+merged_size=$(stat -c %s "$TMPDIR/bloom.layer1-000.dat")
+
+if [[ "$worker_size" != "$merged_size" ]]; then
+  echo "[E] merged bloom shard size mismatch"
+  exit 1
+fi
+
+echo "[+] mapped merge sizing test passed"


### PR DESCRIPTION
## Summary
- Preserve worker-provided bloom sizing and hashing while merging BSGS shards by seeding merge targets from an existing shard and copying chunked outputs
- Pre-validate worker ptable slices, avoid clobbering source slices when the output path overlaps a worker path, and finalize merges from a temporary file
- Add a regression test that merges mapped-size worker slices without re-specifying sizing flags and checks the merged bloom size

## Testing
- make
- ./tests/test_bsgs_merge_mapped_size.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b3ba59710832ea5b57e60b214aa37)