### PR TITLE
Honor bloom reuse without duplicate shards

### DIFF
--- a/keyhunt.cpp
+++ b/keyhunt.cpp
@@ -579,6 +579,7 @@ const char *mapped_dir = NULL;
 const char *worker_outdir = NULL;
 uint32_t worker_id = 0;
 uint32_t worker_total = 1;
+int FLAGWORKERREUSEBLOOM = 0;
 uint64_t mapped_entries_override = 0;
 long double mapped_error_override = 0;
 long double mapped_bpe_override = 0;
@@ -737,11 +738,11 @@ static std::string resolve_bloom_path_for_worker(const std::string &base_path, b
                 return std::string();
         }
         std::string fname = path_basename(base_path);
-        std::string dir = worker_directory_for_path(path_dirname(base_path), worker_override, total_override);
-        if (!ensure_directory_exists(dir, readonly)) {
-                return std::string();
-        }
-        if (!dir.empty() && dir.back() != '/') {
+	std::string dir = worker_directory_for_path(path_dirname(base_path), worker_override, total_override);
+	if (!ensure_directory_exists(dir, readonly)) {
+		return std::string();
+	}
+	if (!dir.empty() && dir.back() != '/') {
                 dir.push_back('/');
         }
         return dir + fname;
@@ -815,20 +816,25 @@ static void write_worker_metadata(const std::string &ptable_path, bool md5_ready
                 md5_to_hex(bptable_md5, md5_hex);
         }
         char *n_hex = BSGS_N.GetBase16();
-        char *range_start_hex = n_range_start.GetBase16();
-        char *range_end_hex = n_range_end.GetBase16();
-        FILE *meta = fopen(meta_path.c_str(), "w");
-        if(!meta){
-                fprintf(stderr,"[W] Unable to write worker metadata to %s\n", meta_path.c_str());
-        } else {
-                fprintf(meta,
-                        "worker_id=%" PRIu32 "\n"
-                        "worker_total=%" PRIu32 "\n"
-                        "ptable_path=%s\n"
-                        "ptable_slice_start=%" PRIu64 "\n"
-                        "ptable_slice_end=%" PRIu64 "\n"
-                        "ptable_slice_len=%" PRIu64 "\n"
-                        "ptable_entries_total=%" PRIu64 "\n"
+	char *range_start_hex = n_range_start.GetBase16();
+	char *range_end_hex = n_range_end.GetBase16();
+	FILE *meta = fopen(meta_path.c_str(), "w");
+	if(!meta){
+		fprintf(stderr,"[W] Unable to write worker metadata to %s\n", meta_path.c_str());
+	} else {
+		uint32_t bloom_source = worker_id;
+		if (worker_total > 1 && worker_id > 0 && FLAGWORKERREUSEBLOOM) {
+			bloom_source = 0;
+		}
+			fprintf(meta,
+				"worker_id=%" PRIu32 "\n"
+				"worker_total=%" PRIu32 "\n"
+				"bloom_source_worker=%" PRIu32 "\n"
+				"ptable_path=%s\n"
+			"ptable_slice_start=%" PRIu64 "\n"
+			"ptable_slice_end=%" PRIu64 "\n"
+			"ptable_slice_len=%" PRIu64 "\n"
+			"ptable_entries_total=%" PRIu64 "\n"
                         "N=0x%s\n"
                         "k=%d\n"
                         "M=%" PRIu64 "\n"
@@ -841,8 +847,9 @@ static void write_worker_metadata(const std::string &ptable_path, bool md5_ready
                         "range_end=0x%s\n"
                         "ptable_md5=%s\n",
                         worker_id,
-                        worker_total,
-                        ptable_path.empty() ? "(memory)" : ptable_path.c_str(),
+	                        worker_total,
+	                        bloom_source,
+	                        ptable_path.empty() ? "(memory)" : ptable_path.c_str(),
                         ptable_slice_start,
                         ptable_slice_end,
                         ptable_slice_len,
@@ -857,18 +864,36 @@ static void write_worker_metadata(const std::string &ptable_path, bool md5_ready
                         mapped_chunks,
                         range_start_hex,
                         range_end_hex,
-                        md5_ready ? md5_hex : "(unavailable)");
-                fclose(meta);
-                printf("[i] Worker metadata saved to %s\n", meta_path.c_str());
-        }
-        free(n_hex);
-        free(range_start_hex);
-        free(range_end_hex);
+			md5_ready ? md5_hex : "(unavailable)");
+		fclose(meta);
+		printf("[i] Worker metadata saved to %s\n", meta_path.c_str());
+	}
+	free(n_hex);
+	free(range_start_hex);
+	free(range_end_hex);
 }
 
 static std::string build_bloom_shard_path(uint32_t layer, uint32_t bucket, const char *fallback_prefix, uint32_t worker_override = std::numeric_limits<uint32_t>::max(), uint32_t total_override = std::numeric_limits<uint32_t>::max());
+
+static bool load_shared_bloom_layer(uint32_t layer, uint64_t items_expected, struct bloom *blooms, const char *label) {
+	const char *prefix = (layer == 1) ? "bloom" : (layer == 2 ? "bloom2" : "bloom3");
+	uint32_t chunks = mapped_chunks ? mapped_chunks : 1;
+	printf("[i] worker %" PRIu32 " reusing %s shards from worker0 (layer %u, %" PRIu64 " items)\n",
+	       worker_id, label, layer, items_expected);
+	for (uint32_t bucket = 0; bucket < 256; bucket++) {
+		std::string shard_path = build_bloom_shard_path(layer, bucket, prefix, 0, worker_total);
+		bloom_set_readonly(1);
+		if (bloom_load_mmap(&blooms[bucket], shard_path.c_str(), chunks) != 0) {
+			fprintf(stderr, "[E] Unable to load shared bloom shard %s for reuse\n", shard_path.c_str());
+			return false;
+		}
+	}
+	bloom_set_readonly(0);
+	return true;
+}
+
 static std::string build_bloom_shard_path_internal(uint32_t layer, uint32_t bucket, const char *fallback_prefix, const char *mapped_override, uint32_t worker_override = std::numeric_limits<uint32_t>::max(), uint32_t total_override = std::numeric_limits<uint32_t>::max()) {
-        const char *mapped_source = mapped_override ? mapped_override : mapped_filename;
+	const char *mapped_source = mapped_override ? mapped_override : mapped_filename;
         std::string mf = mapped_source ? mapped_source : "";
         bool ends_with_sep = (!mf.empty() && (mf.back() == '/' || mf.back() == '\\'));
         std::string mf_dir;
@@ -937,6 +962,7 @@ static std::string build_bloom_shard_path_default_prefix(uint32_t layer, uint32_
 struct WorkerMeta {
         uint32_t worker_id = 0;
         uint32_t worker_total = 0;
+        uint32_t bloom_source_worker = 0; /* bloom shards taken from this worker; defaults to worker_id */
         uint64_t ptable_slice_start = 0;
         uint64_t ptable_slice_end = 0;
         uint64_t ptable_slice_len = 0;
@@ -1011,6 +1037,12 @@ static bool parse_worker_meta_file(const std::string &path, WorkerMeta *out) {
         meta.meta_dir = path_dirname(path);
         if (!parse_uint32(kv, "worker_id", &meta.worker_id)) return false;
         if (!parse_uint32(kv, "worker_total", &meta.worker_total)) return false;
+        auto bs_it = kv.find("bloom_source_worker");
+        if (bs_it != kv.end()) {
+                if (!parse_uint32(kv, "bloom_source_worker", &meta.bloom_source_worker)) return false;
+        } else {
+                meta.bloom_source_worker = meta.worker_id;
+        }
         if (!parse_uint64(kv, "ptable_slice_start", &meta.ptable_slice_start)) return false;
         if (!parse_uint64(kv, "ptable_slice_end", &meta.ptable_slice_end)) return false;
         if (!parse_uint64(kv, "ptable_slice_len", &meta.ptable_slice_len)) return false;
@@ -1259,14 +1291,19 @@ static bool or_merge_bloom_pair(struct bloom *dst, struct bloom *src) {
 
 static bool merge_bloom_shards_for_layer(uint32_t layer, uint64_t items_expected, const std::vector<WorkerMeta> &metas) {
         const char *prefix = (layer == 1) ? "bloom" : (layer == 2 ? "bloom2" : "bloom3");
-        printf("[i] Merging bloom layer %u (%" PRIu64 " items)\n", layer, items_expected);
-        auto load_worker_shard = [&](const WorkerMeta &meta, uint32_t bucket, struct bloom *out, std::string *path_out) -> bool {
-                std::string src_path = build_bloom_shard_path(layer, bucket, prefix, meta.worker_id, meta.worker_total);
-                uint32_t chunks = meta.mapped_chunks_meta ? meta.mapped_chunks_meta : mapped_chunks;
-                if (chunks == 0) {
-                        chunks = 1;
-                }
-                bloom_set_readonly(1);
+	printf("[i] Merging bloom layer %u (%" PRIu64 " items)\n", layer, items_expected);
+	auto load_worker_shard = [&](const WorkerMeta &meta, uint32_t bucket, struct bloom *out, std::string *path_out) -> bool {
+		uint32_t source_worker = meta.bloom_source_worker;
+		if (source_worker >= meta.worker_total) {
+			fprintf(stderr, "[E] Invalid bloom source worker %" PRIu32 " for worker %" PRIu32 "\n", source_worker, meta.worker_id);
+			return false;
+		}
+		std::string src_path = build_bloom_shard_path(layer, bucket, prefix, source_worker, meta.worker_total);
+		uint32_t chunks = meta.mapped_chunks_meta ? meta.mapped_chunks_meta : mapped_chunks;
+		if (chunks == 0) {
+			chunks = 1;
+		}
+		bloom_set_readonly(1);
                 if (bloom_load_mmap(out, src_path.c_str(), chunks) != 0) {
                         // If a custom --bloom-file is used for the merged output, workers may still have the default filenames.
                         // Retry with the default naming scheme to support legacy worker shards.
@@ -1957,6 +1994,7 @@ int main(int argc, char **argv)	{
                {"worker-id", required_argument, 0, 0},
                {"worker-total", required_argument, 0, 0},
                {"worker-outdir", required_argument, 0, 0},
+               {"worker-reuse-bloom", no_argument, 0, 0},
                {"bsgs-merge-from", required_argument, 0, 0},
                {"bsgs-merge-only", no_argument, 0, 0},
                {"bsgs-build-only", no_argument, 0, 0},
@@ -2038,19 +2076,21 @@ int main(int argc, char **argv)	{
                              }
                       } else if (strcmp(long_options[option_index].name, "worker-id") == 0) {
                              worker_id = (uint32_t)strtoul(optarg, NULL, 10);
-                     } else if (strcmp(long_options[option_index].name, "worker-total") == 0) {
-                             worker_total = (uint32_t)strtoul(optarg, NULL, 10);
-                             if(worker_total == 0){
-                                     fprintf(stderr, "[W] --worker-total must be at least 1; defaulting to 1\n");
-                                     worker_total = 1;
-                             }
-                     } else if (strcmp(long_options[option_index].name, "worker-outdir") == 0) {
-                             worker_outdir = optarg;
-                     } else if (strcmp(long_options[option_index].name, "bsgs-merge-from") == 0) {
-                             bsgs_merge_from = optarg;
-                     } else if (strcmp(long_options[option_index].name, "bsgs-merge-only") == 0) {
-                             FLAGBSGSMERGEONLY = 1;
-                     } else if (strcmp(long_options[option_index].name, "bsgs-build-only") == 0) {
+			} else if (strcmp(long_options[option_index].name, "worker-total") == 0) {
+				worker_total = (uint32_t)strtoul(optarg, NULL, 10);
+				if(worker_total == 0){
+					fprintf(stderr, "[W] --worker-total must be at least 1; defaulting to 1\n");
+					worker_total = 1;
+			}
+			} else if (strcmp(long_options[option_index].name, "worker-outdir") == 0) {
+				worker_outdir = optarg;
+			} else if (strcmp(long_options[option_index].name, "worker-reuse-bloom") == 0) {
+				FLAGWORKERREUSEBLOOM = 1;
+			} else if (strcmp(long_options[option_index].name, "bsgs-merge-from") == 0) {
+				bsgs_merge_from = optarg;
+			} else if (strcmp(long_options[option_index].name, "bsgs-merge-only") == 0) {
+				FLAGBSGSMERGEONLY = 1;
+			} else if (strcmp(long_options[option_index].name, "bsgs-build-only") == 0) {
                              FLAGBSGSBUILDONLY = 1;
                      } else if (strcmp(long_options[option_index].name, "bloom-file") == 0) {
                              mapped_filename = optarg;
@@ -3101,19 +3141,30 @@ free(hextemp);
                         (effective_blocks > 1) ? "GGSB" : "classic",
                         effective_blocks,
                         block_babies);
-                fprintf(stderr,
-                        "[i] Expected sizes: each bloom layer ~%.2f MB (256 shards), bPtable ~%.2f MB per block (%.2f MB total).\n",
-                        layer_total_mb, ptable_mb, ptable_total_mb);
+	fprintf(stderr,
+		"[i] Expected sizes: each bloom layer ~%.2f MB (256 shards), bPtable ~%.2f MB per block (%.2f MB total).\n",
+		layer_total_mb, ptable_mb, ptable_total_mb);
 
-                std::string bloom_preview = build_bloom_shard_path(1, 0, "bloom");
-                std::string bloom_dir = path_dirname(bloom_preview);
-                printf("[i] Bloom shards will be stored under %s (example: %s)\n", bloom_dir.c_str(), bloom_preview.c_str());
+	bool worker_reuse_bloom = (worker_total > 1 && worker_id > 0 && FLAGWORKERREUSEBLOOM);
+	if(worker_reuse_bloom){
+		FLAGLOADBLOOM = 1;
+	}
 
-                printf("[+] Bloom filter for %" PRIu64 " elements ",bsgs_m);
-		bloom_bP = (struct bloom*)calloc(256,sizeof(struct bloom));
-		checkpointer((void *)bloom_bP,__FILE__,"calloc","bloom_bP" ,__LINE__ -1 );
-		bloom_bP_checksums = (struct checksumsha256*)calloc(256,sizeof(struct checksumsha256));
-		checkpointer((void *)bloom_bP_checksums,__FILE__,"calloc","bloom_bP_checksums" ,__LINE__ -1 );
+	std::string bloom_preview = worker_reuse_bloom
+		? build_bloom_shard_path(1, 0, "bloom", 0, worker_total)
+		: build_bloom_shard_path(1, 0, "bloom");
+	std::string bloom_dir = path_dirname(bloom_preview);
+	if(worker_reuse_bloom){
+		printf("[i] Bloom shards will be reused from %s (example: %s)\n", bloom_dir.c_str(), bloom_preview.c_str());
+	}else{
+		printf("[i] Bloom shards will be stored under %s (example: %s)\n", bloom_dir.c_str(), bloom_preview.c_str());
+	}
+
+	printf("[+] Bloom filter for %" PRIu64 " elements ",bsgs_m);
+	bloom_bP = (struct bloom*)calloc(256,sizeof(struct bloom));
+	checkpointer((void *)bloom_bP,__FILE__,"calloc","bloom_bP" ,__LINE__ -1 );
+	bloom_bP_checksums = (struct checksumsha256*)calloc(256,sizeof(struct checksumsha256));
+	checkpointer((void *)bloom_bP_checksums,__FILE__,"calloc","bloom_bP_checksums" ,__LINE__ -1 );
 		
 #if defined(_WIN64) && !defined(__CYGWIN__)
 		bloom_bP_mutex = (HANDLE*) calloc(256,sizeof(HANDLE));
@@ -3124,27 +3175,40 @@ free(hextemp);
 		checkpointer((void *)bloom_bP_mutex,__FILE__,"calloc","bloom_bP_mutex" ,__LINE__ -1 );
 		
 
-		fflush(stdout);
-		bloom_bP_totalbytes = 0;
-		for(i=0; i< 256; i++)	{
+	fflush(stdout);
+	bloom_bP_totalbytes = 0;
+	for(i=0; i< 256; i++)	{
 #if defined(_WIN64) && !defined(__CYGWIN__)
-			bloom_bP_mutex[i] = CreateMutex(NULL, FALSE, NULL);
+		bloom_bP_mutex[i] = CreateMutex(NULL, FALSE, NULL);
 #else
-			pthread_mutex_init(&bloom_bP_mutex[i],NULL);
+		pthread_mutex_init(&bloom_bP_mutex[i],NULL);
 #endif
-                        std::string fname = build_bloom_shard_path(1, i, "bloom");
-                        if(!initBloomFilterMapped(&bloom_bP[i],itemsbloom,fname.c_str())){
-                                fprintf(stderr,"[E] error bloom_init _ [%" PRIu64 "]\n",i);
-                                exit(EXIT_FAILURE);
-                        }
+	}
+	if(worker_reuse_bloom){
+		if(!load_shared_bloom_layer(1, bsgs_m, bloom_bP, "layer1")){
+			exit(EXIT_FAILURE);
+		}
+		for(i=0; i<256; i++){
+			bloom_bP_totalbytes += bloom_bP[i].bytes;
+		}
+		FLAGREADEDFILE1 = 1;
+		printf(": %.2f MB (shared)\n",(float)((float)(uint64_t)bloom_bP_totalbytes/(float)(uint64_t)1048576));
+	} else {
+		for(i=0; i< 256; i++)	{
+	                std::string fname = build_bloom_shard_path(1, i, "bloom");
+	                if(!initBloomFilterMapped(&bloom_bP[i],itemsbloom,fname.c_str())){
+	                        fprintf(stderr,"[E] error bloom_init _ [%" PRIu64 "]\n",i);
+	                        exit(EXIT_FAILURE);
+	                }
 			bloom_bP_totalbytes += bloom_bP[i].bytes;
 			//if(FLAGDEBUG) bloom_print(&bloom_bP[i]);
 		}
 		printf(": %.2f MB\n",(float)((float)(uint64_t)bloom_bP_totalbytes/(float)(uint64_t)1048576));
+	}
 
 
-		printf("[+] Bloom filter for %" PRIu64 " elements ",bsgs_m2);
-		
+	printf("[+] Bloom filter for %" PRIu64 " elements ",bsgs_m2);
+
 #if defined(_WIN64) && !defined(__CYGWIN__)
 		bloom_bPx2nd_mutex = (HANDLE*) calloc(256,sizeof(HANDLE));
 #else
@@ -3154,53 +3218,79 @@ free(hextemp);
 		bloom_bPx2nd = (struct bloom*)calloc(256,sizeof(struct bloom));
 		checkpointer((void *)bloom_bPx2nd,__FILE__,"calloc","bloom_bPx2nd" ,__LINE__ -1 );
 		bloom_bPx2nd_checksums = (struct checksumsha256*) calloc(256,sizeof(struct checksumsha256));
-		checkpointer((void *)bloom_bPx2nd_checksums,__FILE__,"calloc","bloom_bPx2nd_checksums" ,__LINE__ -1 );
-		bloom_bP2_totalbytes = 0;
-		for(i=0; i< 256; i++)	{
+	checkpointer((void *)bloom_bPx2nd_checksums,__FILE__,"calloc","bloom_bPx2nd_checksums" ,__LINE__ -1 );
+	bloom_bP2_totalbytes = 0;
+	for(i=0; i< 256; i++)	{
 #if defined(_WIN64) && !defined(__CYGWIN__)
-			bloom_bPx2nd_mutex[i] = CreateMutex(NULL, FALSE, NULL);
+		bloom_bPx2nd_mutex[i] = CreateMutex(NULL, FALSE, NULL);
 #else
-			pthread_mutex_init(&bloom_bPx2nd_mutex[i],NULL);
+		pthread_mutex_init(&bloom_bPx2nd_mutex[i],NULL);
 #endif
-                        std::string fname2 = build_bloom_shard_path(2, i, "bloom2");
-                        if(!initBloomFilterMapped(&bloom_bPx2nd[i],itemsbloom2,fname2.c_str())){
-                                fprintf(stderr,"[E] error bloom_init _ [%" PRIu64 "]\n",i);
-                                exit(EXIT_FAILURE);
-                        }
+	}
+	if(worker_reuse_bloom){
+		if(!load_shared_bloom_layer(2, bsgs_m2, bloom_bPx2nd, "layer2")){
+			exit(EXIT_FAILURE);
+		}
+		for(i=0; i<256; i++){
+			bloom_bP2_totalbytes += bloom_bPx2nd[i].bytes;
+		}
+		FLAGREADEDFILE2 = 1;
+		printf(": %.2f MB (shared)\n",(float)((float)(uint64_t)bloom_bP2_totalbytes/(float)(uint64_t)1048576));
+	} else {
+		for(i=0; i< 256; i++)	{
+	                std::string fname2 = build_bloom_shard_path(2, i, "bloom2");
+	                if(!initBloomFilterMapped(&bloom_bPx2nd[i],itemsbloom2,fname2.c_str())){
+	                        fprintf(stderr,"[E] error bloom_init _ [%" PRIu64 "]\n",i);
+	                        exit(EXIT_FAILURE);
+	                }
 			bloom_bP2_totalbytes += bloom_bPx2nd[i].bytes;
 			//if(FLAGDEBUG) bloom_print(&bloom_bPx2nd[i]);
 		}
 		printf(": %.2f MB\n",(float)((float)(uint64_t)bloom_bP2_totalbytes/(float)(uint64_t)1048576));
-		
+	}
+
 
 #if defined(_WIN64) && !defined(__CYGWIN__)
-		bloom_bPx3rd_mutex = (HANDLE*) calloc(256,sizeof(HANDLE));
+	bloom_bPx3rd_mutex = (HANDLE*) calloc(256,sizeof(HANDLE));
 #else
 		bloom_bPx3rd_mutex = (pthread_mutex_t*) calloc(256,sizeof(pthread_mutex_t));
 #endif
 		checkpointer((void *)bloom_bPx3rd_mutex,__FILE__,"calloc","bloom_bPx3rd_mutex" ,__LINE__ -1 );
 		bloom_bPx3rd = (struct bloom*)calloc(256,sizeof(struct bloom));
-		checkpointer((void *)bloom_bPx3rd,__FILE__,"calloc","bloom_bPx3rd" ,__LINE__ -1 );
-		bloom_bPx3rd_checksums = (struct checksumsha256*) calloc(256,sizeof(struct checksumsha256));
-		checkpointer((void *)bloom_bPx3rd_checksums,__FILE__,"calloc","bloom_bPx3rd_checksums" ,__LINE__ -1 );
-		
-		printf("[+] Bloom filter for %" PRIu64 " elements ",bsgs_m3);
-		bloom_bP3_totalbytes = 0;
-		for(i=0; i< 256; i++)	{
+	checkpointer((void *)bloom_bPx3rd,__FILE__,"calloc","bloom_bPx3rd" ,__LINE__ -1 );
+	bloom_bPx3rd_checksums = (struct checksumsha256*) calloc(256,sizeof(struct checksumsha256));
+	checkpointer((void *)bloom_bPx3rd_checksums,__FILE__,"calloc","bloom_bPx3rd_checksums" ,__LINE__ -1 );
+	
+	printf("[+] Bloom filter for %" PRIu64 " elements ",bsgs_m3);
+	bloom_bP3_totalbytes = 0;
+	for(i=0; i< 256; i++)	{
 #if defined(_WIN64) && !defined(__CYGWIN__)
-			bloom_bPx3rd_mutex[i] = CreateMutex(NULL, FALSE, NULL);
+		bloom_bPx3rd_mutex[i] = CreateMutex(NULL, FALSE, NULL);
 #else
-			pthread_mutex_init(&bloom_bPx3rd_mutex[i],NULL);
+		pthread_mutex_init(&bloom_bPx3rd_mutex[i],NULL);
 #endif
-                        std::string fname3 = build_bloom_shard_path(3, i, "bloom3");
-                        if(!initBloomFilterMapped(&bloom_bPx3rd[i],itemsbloom3,fname3.c_str())){
-                                fprintf(stderr,"[E] error bloom_init [%" PRIu64 "]\n",i);
-                                exit(EXIT_FAILURE);
-                        }
+	}
+	if(worker_reuse_bloom){
+		if(!load_shared_bloom_layer(3, bsgs_m3, bloom_bPx3rd, "layer3")){
+			exit(EXIT_FAILURE);
+		}
+		for(i=0; i<256; i++){
+			bloom_bP3_totalbytes += bloom_bPx3rd[i].bytes;
+		}
+		FLAGREADEDFILE4 = 1;
+		printf(": %.2f MB (shared)\n",(float)((float)(uint64_t)bloom_bP3_totalbytes/(float)(uint64_t)1048576));
+	} else {
+		for(i=0; i< 256; i++)	{
+	                std::string fname3 = build_bloom_shard_path(3, i, "bloom3");
+	                if(!initBloomFilterMapped(&bloom_bPx3rd[i],itemsbloom3,fname3.c_str())){
+	                        fprintf(stderr,"[E] error bloom_init [%" PRIu64 "]\n",i);
+	                        exit(EXIT_FAILURE);
+	                }
 			bloom_bP3_totalbytes += bloom_bPx3rd[i].bytes;
 			//if(FLAGDEBUG) bloom_print(&bloom_bPx3rd[i]);
 		}
 		printf(": %.2f MB\n",(float)((float)(uint64_t)bloom_bP3_totalbytes/(float)(uint64_t)1048576));
+	}
 		//if(FLAGDEBUG) printf("[D] bloom_bP3_totalbytes : %" PRIu64 "\n",bloom_bP3_totalbytes);
 
 		if(FLAGLOADBLOOM){
@@ -8224,15 +8314,16 @@ printf("-z value    Bloom size multiplier, only address,rmd160,vanity, xpoint, v
         printf("--mapped-dir dir  Directory for mapped bloom shard files (defaults to --tmpdir or cwd)\n");
         printf("--mapped-error f  Target false-positive rate for mapped blooms (e.g., 1e-6)\n");
         printf("--mapped-bpe f    Target bits-per-entry for mapped blooms (derives error)\n");
-        printf("--mapped-plan     Print mapped bloom sizing recommendations and exit\n");
-        printf("--mapped-populate {0,1}  Request MAP_POPULATE when memory-mapping blooms (default 0)\n");
-        printf("--mapped-willneed {0,1}  Request MADV_WILLNEED for mapped blooms/ptables (default 0)\n");
-        printf("--worker-id n     Worker index for sharded bloom outputs (default 0)\n");
-        printf("--worker-total n  Total workers responsible for bP table slices (default 1)\n");
-        printf("--worker-outdir dir  Base directory for worker-local bloom files\n");
-        printf("--bloom-bytes sz  Desired on-disk size for mapped bloom filter in bytes\n");
-        printf("--create-mapped[=sz]  Create and zero a mapped bloom filter file then exit\n");
-        printf("--bloom-file file  Explicit path to mapped bloom file (alias of --mapped=file)\n");
+	printf("--mapped-plan     Print mapped bloom sizing recommendations and exit\n");
+	printf("--mapped-populate {0,1}  Request MAP_POPULATE when memory-mapping blooms (default 0)\n");
+	printf("--mapped-willneed {0,1}  Request MADV_WILLNEED for mapped blooms/ptables (default 0)\n");
+	printf("--worker-id n     Worker index for sharded bloom outputs (default 0)\n");
+	printf("--worker-total n  Total workers responsible for bP table slices (default 1)\n");
+	printf("--worker-outdir dir  Base directory for worker-local bloom files\n");
+	printf("--worker-reuse-bloom  For worker>0, reuse worker0 bloom shards instead of rebuilding them\n");
+	printf("--bloom-bytes sz  Desired on-disk size for mapped bloom filter in bytes\n");
+	printf("--create-mapped[=sz]  Create and zero a mapped bloom filter file then exit\n");
+	printf("--bloom-file file  Explicit path to mapped bloom file (alias of --mapped=file)\n");
 	printf("--load-bloom       Require existing mapped bloom file; do not create a new one\n");
         printf("--bsgs-merge-from <glob|dir>  Merge worker bloom shards and ptable slices using metadata\n");
         printf("--bsgs-merge-only  Stop after merge (do not recompute)\n");


### PR DESCRIPTION
### Motivation

- Avoid creating duplicate bloom shard files when running multiple workers by reusing worker0's bloom shards for non-zero workers.
- Record which worker provides shared bloom shards so the merge step reads the correct source instead of expecting per-worker copies.
- Keep the existing merge pipeline compatible while removing unnecessary file copies and symlinks.

### Description

- Add `--worker-reuse-bloom` flag (`FLAGWORKERREUSEBLOOM`) to instruct non-zero workers to reuse worker0 bloom shards and enable read-only loading.
- Add `bloom_source_worker` to `WorkerMeta`, write it into worker `.meta` files, and parse it back when loading metadata.
- Implement `load_shared_bloom_layer` to `mmap` bloom shards directly from the source worker (no symlink/copy), and modify the merge loader to load shards from `meta.bloom_source_worker`.
- Make worker build logic set `FLAGLOADBLOOM` for reuse-mode workers and display reused shard paths in the output instead of creating duplicate files.

### Testing

- Built the project with `make -j2`; build completed successfully with compiler warnings about missing bloom struct initializers (non-fatal). (succeeded)
- Ran a two-worker BSGS build-only run for `worker 0` with `--bsgs-build-only` and it created canonical blooms under `worker0`. (succeeded)
- Ran `worker 1` with `--load-bloom --worker-reuse-bloom --bsgs-build-only` and it loaded shared blooms from `worker0` without creating per-worker bloom files. (succeeded)
- Ran `--bsgs-merge-only` with the generated metadata and it merged bloom layers and ptable correctly producing canonical artifacts. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c3a51bf84832e8f1dc3187a247a3d)